### PR TITLE
feat: 축제 즐겨찾기 페이지 UI 구현

### DIFF
--- a/src/app/festival/_components/FestivalListItem.js
+++ b/src/app/festival/_components/FestivalListItem.js
@@ -6,7 +6,7 @@ import { FaCommentAlt } from 'react-icons/fa';
 export default function FestivalListItem({
   festival,
   liked = false,
-  onLike = () => {},
+  onLike = null,
   hideLikeButton = false,
 }) {
   return (

--- a/src/app/festival/_components/FestivalListItem.js
+++ b/src/app/festival/_components/FestivalListItem.js
@@ -10,65 +10,63 @@ export default function FestivalListItem({
   hideLikeButton = false,
 }) {
   return (
-    <div className="bg-white">
-      <div className="flex gap-3">
-        <div className="relative w-20 h-20 rounded-lg overflow-hidden flex-shrink-0">
-          <img
-            src={festival.thumbnail}
-            alt={festival.title}
-            className="w-full h-full object-cover"
-          />
-          {!hideLikeButton && (
-            <button onClick={onLike} className="absolute top-1 left-1 z-10">
-              {liked ? (
-                <GoHeartFill className="text-main-100 w-4 h-4 drop-shadow" />
-              ) : (
-                <GoHeart className="text-white w-4 h-4 drop-shadow" />
-              )}
-            </button>
-          )}
-        </div>
+    <div className={` flex gap-3 ${hideLikeButton ? 'px-4 py-2' : ''}  `}>
+      <div className="relative w-20 h-20 rounded-lg overflow-hidden flex-shrink-0">
+        <img
+          src={festival.thumbnail}
+          alt={festival.title}
+          className="w-full h-full object-cover"
+        />
+        {!hideLikeButton && (
+          <button onClick={onLike} className="absolute top-1 left-1 z-10">
+            {liked ? (
+              <GoHeartFill className="text-main-100 w-4 h-4 drop-shadow" />
+            ) : (
+              <GoHeart className="text-white w-4 h-4 drop-shadow" />
+            )}
+          </button>
+        )}
+      </div>
 
-        <div className="flex flex-col justify-between flex-1 pr-1">
-          <div>
-            <div className="flex flex-wrap gap-1 mb-1 text-[11px]">
+      <div className="flex flex-col justify-between flex-1 pr-1">
+        <div>
+          <div className="flex flex-wrap gap-1 mb-1 text-[11px]">
+            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+              {festival.region}
+            </span>
+            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+              {festival.category}
+            </span>
+            {festival.reviews.length > 0 && (
               <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                {festival.region}
+                후기 {festival.reviews.length}개
               </span>
-              <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                {festival.category}
-              </span>
-              {festival.reviews.length > 0 && (
-                <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                  후기 {festival.reviews.length}개
-                </span>
-              )}
-              <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                {festival.price === 0 ? '무료' : '유료'}
-              </span>
-            </div>
-
-            <div className="font-bold text-sm mt-1.5 truncate">
-              {festival.title}
-            </div>
-            <div className="text-neutral-600 mt-0.5 text-xs truncate">
-              {festival.location}
-            </div>
+            )}
+            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+              {festival.price === 0 ? '무료' : '유료'}
+            </span>
           </div>
 
-          <div className="flex justify-between items-end mt-2">
-            <div className="text-neutral-400 text-[11px] font-thin">
-              {festival.startDate}~{festival.endDate}
+          <div className="font-bold text-sm mt-1.5 truncate">
+            {festival.title}
+          </div>
+          <div className="text-neutral-600 mt-0.5 text-xs truncate">
+            {festival.location}
+          </div>
+        </div>
+
+        <div className="flex justify-between items-end mt-2">
+          <div className="text-neutral-400 text-[11px] font-thin">
+            {festival.startDate}~{festival.endDate}
+          </div>
+          <div className="flex gap-3 text-[11px]">
+            <div className="flex items-center gap-1 text-main-100">
+              <GoHeartFill className="w-3.5 h-3.5" />
+              <span>{festival.likes}</span>
             </div>
-            <div className="flex gap-3 text-[11px]">
-              <div className="flex items-center gap-1 text-main-100">
-                <GoHeartFill className="w-3.5 h-3.5" />
-                <span>{festival.likes}</span>
-              </div>
-              <div className="flex items-center gap-1 text-main-100">
-                <FaCommentAlt className="w-3.5 h-3.5" />
-                <span>{festival.reviews.length}</span>
-              </div>
+            <div className="flex items-center gap-1 text-main-100">
+              <FaCommentAlt className="w-3.5 h-3.5" />
+              <span>{festival.reviews.length}</span>
             </div>
           </div>
         </div>

--- a/src/app/festival/_components/FestivalListItem.js
+++ b/src/app/festival/_components/FestivalListItem.js
@@ -3,7 +3,12 @@
 import { GoHeart, GoHeartFill } from 'react-icons/go';
 import { FaCommentAlt } from 'react-icons/fa';
 
-export default function FestivalListItem({ festival, liked, onLike }) {
+export default function FestivalListItem({
+  festival,
+  liked = false,
+  onLike = () => {},
+  hideLikeButton = false,
+}) {
   return (
     <div className="bg-white">
       <div className="flex gap-3">
@@ -13,14 +18,17 @@ export default function FestivalListItem({ festival, liked, onLike }) {
             alt={festival.title}
             className="w-full h-full object-cover"
           />
-          <button onClick={onLike} className="absolute top-1 left-1 z-10">
-            {liked ? (
-              <GoHeartFill className="text-main-100 w-4 h-4 drop-shadow" />
-            ) : (
-              <GoHeart className="text-white w-4 h-4 drop-shadow" />
-            )}
-          </button>
+          {!hideLikeButton && (
+            <button onClick={onLike} className="absolute top-1 left-1 z-10">
+              {liked ? (
+                <GoHeartFill className="text-main-100 w-4 h-4 drop-shadow" />
+              ) : (
+                <GoHeart className="text-white w-4 h-4 drop-shadow" />
+              )}
+            </button>
+          )}
         </div>
+
         <div className="flex flex-col justify-between flex-1 pr-1">
           <div>
             <div className="flex flex-wrap gap-1 mb-1 text-[11px]">
@@ -30,9 +38,11 @@ export default function FestivalListItem({ festival, liked, onLike }) {
               <span className="text-main-100 bg-main-5 px-1 rounded-full">
                 {festival.category}
               </span>
-              <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                후기 {festival.reviews.length}개
-              </span>
+              {festival.reviews.length > 0 && (
+                <span className="text-main-100 bg-main-5 px-1 rounded-full">
+                  후기 {festival.reviews.length}개
+                </span>
+              )}
               <span className="text-main-100 bg-main-5 px-1 rounded-full">
                 {festival.price === 0 ? '무료' : '유료'}
               </span>

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -42,7 +42,7 @@ export default function BookmarkPage() {
   };
 
   return (
-    <div className="max-w-[390px] mx-auto min-h-screen bg-white pb-28">
+    <div className="max-w-[390px] mx-auto h-screen bg-white pb-28">
       {/* 상단 헤더 */}
       <div className="relative w-full h-[60px] flex items-center justify-center px-4 ">
         {editMode ? (
@@ -68,55 +68,65 @@ export default function BookmarkPage() {
         )}
       </div>
 
-      {bookmarks.length === 0 && (
-        <div className="flex flex-col items-center justify-center mt-32 text-center px-8 gap-4">
-          <i className="mgc_emotion_unhappy_line text-6xl text-main-100" />
-          <div className="text-base font-semibold">
-            앗, 저장된 축제가 없어요!
-          </div>
-          <p className="text-sm text-neutral-500">
-            방문하고 싶으신 축제를 저장해 주세요 🥲
-          </p>
-          <button
-            onClick={() => router.push('/festival')}
-            className="mt-4 px-6 py-2 rounded-md bg-main-5 text-main-100 text-sm font-medium"
+      <div className="space-y-4 h-full">
+        {bookmarks.length === 0 && (
+          <div
+            className="flex flex-col h-full items-center justify-center gap-3"
+            style={{ height: 'calc(100% - 80px)' }}
           >
-            축제 메인으로 돌아가기
-          </button>
-        </div>
-      )}
+            <i className="mgc_sweats_fill text-6xl text-main-100" />
+            <p className="text-center text-lg font-semibold">
+              앗, 저장된 축제가 없어요!
+            </p>
+            <p className="text-center text-sm text-neutral-500">
+              방문하고 싶으신 축제를 저장해 주세요 ☺️
+            </p>
+            <button
+              onClick={() => router.push('/festival')}
+              className="mt-4 px-6 py-2 rounded-md bg-main-5 text-main-100 text-xl font-medium "
+            >
+              축제 메인으로 돌아가기
+            </button>
+          </div>
+        )}
+      </div>
 
       {bookmarks.length > 0 && (
         <div className="space-y-4 px-4 pt-3">
-          {bookmarks.map((festival) => (
-            <div
-              key={festival.id}
-              className="relative"
-              onClick={() => {
-                if (!editMode) router.push(`/festival/${festival.id}`);
-              }}
-            >
-              <FestivalListItem festival={festival} hideLikeButton={true} />
-              {editMode && (
-                <button
-                  onClick={() => toggleSelect(festival.id)}
-                  className="absolute right-2 top-2 w-5 h-5 rounded-full border-2 border-main-100 bg-white flex items-center justify-center"
-                >
-                  {selectedIds.includes(festival.id) && (
-                    <div className="w-3 h-3 rounded-full bg-main-100" />
-                  )}
-                </button>
-              )}
-            </div>
-          ))}
+          {bookmarks.map((festival) => {
+            const isSelected = selectedIds.includes(festival.id);
+
+            return (
+              <div
+                key={festival.id}
+                className={` relative rounded-md ${isSelected && editMode ? 'bg-sub-15' : ''} `}
+              >
+                <FestivalListItem festival={festival} hideLikeButton={true} />
+                {editMode && (
+                  <button
+                    onClick={() => toggleSelect(festival.id)}
+                    className="absolute right-2 -top-1 text-xl z-10"
+                  >
+                    <i
+                      className={`${
+                        isSelected
+                          ? 'mgc_check_circle_fill text-sub-100'
+                          : 'mgc_check_circle_line text-neutral-300'
+                      }`}
+                    />
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 
       {/* 하단 삭제 버튼 */}
-      {editMode && (
+      {selectedIds.length > 0 && (
         <button
           onClick={() => setShowDeleteModal(true)}
-          className="fixed bottom-20 left-1/2 -translate-x-1/2 w-[350px] py-2 bg-main-100 text-white rounded-lg text-sm font-medium shadow-md"
+          className="fixed bottom-20 left-1/2 -translate-x-1/2 w-[350px] py-2 bg-main-100 text-background text-lg rounded-lg font-medium shadow-md"
         >
           {selectedIds.length > 0
             ? `${selectedIds.length}개 삭제하기`
@@ -127,21 +137,24 @@ export default function BookmarkPage() {
       {/* 삭제 모달 */}
       {showDeleteModal && (
         <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center">
-          <div className="bg-white w-[80%] rounded-xl p-6 text-center space-y-4">
-            <p className="text-base font-medium">즐겨찾기를 삭제하시겠어요?</p>
-            <p className="text-sm text-neutral-500">
+          <div className="bg-white w-[75%] max-w-[390px] rounded-xl p-4 text-center shadow-lg">
+            <p className="text-base font-semibold mt-3">
+              즐겨찾기를 삭제하시겠어요?
+            </p>
+            <p className="text-base font-semibold">
               삭제된 즐겨찾기는 복구가 불가능해요!
             </p>
-            <div className="flex gap-3 mt-4">
+            <div className="flex gap-3 mt-8">
               <button
                 onClick={() => setShowDeleteModal(false)}
-                className="flex-1 py-2 border border-main-100 rounded-md text-main-100"
+                className="flex-1 py-2.5 bg-main-5 text-main-100 font-semibold rounded-md shadow-[0_0_3px_rgba(0,0,0,0.1)]"
               >
                 취소할래요
               </button>
+
               <button
                 onClick={handleDelete}
-                className="flex-1 py-2 bg-main-100 text-white rounded-md"
+                className="flex-1 py-2.5 bg-main-100 text-background font-semibold rounded-md"
               >
                 삭제할래요
               </button>

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -68,8 +68,8 @@ export default function BookmarkPage() {
         )}
       </div>
 
-      <div className="space-y-4 h-full">
-        {bookmarks.length === 0 && (
+      {bookmarks.length === 0 && (
+        <div className="space-y-4 h-full">
           <div
             className="flex flex-col h-full items-center justify-center gap-3"
             style={{ height: 'calc(100% - 80px)' }}
@@ -87,9 +87,9 @@ export default function BookmarkPage() {
             >
               축제 메인으로 돌아가기
             </button>
-          </div>
-        )}
-      </div>
+          </div>{' '}
+        </div>
+      )}
 
       {bookmarks.length > 0 && (
         <div className="space-y-4 px-4 pt-3">

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -63,7 +63,11 @@ export default function BookmarkPage() {
             onClick={editMode ? toggleAll : () => setEditMode(true)}
             className="absolute right-4 text-sm text-main-100"
           >
-            {editMode ? '전체선택' : '편집'}
+            {editMode
+              ? selectedIds.length === bookmarks.length
+                ? '전체해제'
+                : '전체선택'
+              : '편집'}
           </button>
         )}
       </div>

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import FestivalListItem from '@/app/festival/_components/FestivalListItem';
+import { mockFestivals } from '@/app/festival/mockData';
+import BackButton from '@/app/_components/BackButton';
+
+export default function BookmarkPage() {
+  const router = useRouter();
+  const [bookmarks, setBookmarks] = useState(mockFestivals);
+  const [editMode, setEditMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const handleDelete = () => {
+    setBookmarks((prev) =>
+      prev.filter((item) => !selectedIds.includes(item.id))
+    );
+    setSelectedIds([]);
+    setEditMode(false);
+    setShowDeleteModal(false);
+  };
+
+  const toggleAll = () => {
+    if (selectedIds.length === bookmarks.length) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(bookmarks.map((b) => b.id));
+    }
+  };
+
+  const cancelEdit = () => {
+    setEditMode(false);
+    setSelectedIds([]);
+  };
+
+  return (
+    <div className="max-w-[390px] mx-auto min-h-screen bg-white pb-28">
+      {/* 상단 헤더 */}
+      <div className="relative w-full h-[60px] flex items-center justify-center px-4 ">
+        {editMode ? (
+          <button
+            onClick={cancelEdit}
+            className="absolute left-4 text-sm text-main-100"
+          >
+            취소
+          </button>
+        ) : (
+          <div className="absolute left-4 text-4xl">
+            <BackButton />
+          </div>
+        )}
+        <h1 className="text-lg font-semibold">즐겨찾기</h1>
+        {bookmarks.length > 0 && (
+          <button
+            onClick={editMode ? toggleAll : () => setEditMode(true)}
+            className="absolute right-4 text-sm text-main-100"
+          >
+            {editMode ? '전체선택' : '편집'}
+          </button>
+        )}
+      </div>
+
+      {bookmarks.length === 0 && (
+        <div className="flex flex-col items-center justify-center mt-32 text-center px-8 gap-4">
+          <i className="mgc_emotion_unhappy_line text-6xl text-main-100" />
+          <div className="text-base font-semibold">
+            앗, 저장된 축제가 없어요!
+          </div>
+          <p className="text-sm text-neutral-500">
+            방문하고 싶으신 축제를 저장해 주세요 🥲
+          </p>
+          <button
+            onClick={() => router.push('/festival')}
+            className="mt-4 px-6 py-2 rounded-md bg-main-5 text-main-100 text-sm font-medium"
+          >
+            축제 메인으로 돌아가기
+          </button>
+        </div>
+      )}
+
+      {bookmarks.length > 0 && (
+        <div className="space-y-4 px-4 pt-3">
+          {bookmarks.map((festival) => (
+            <div
+              key={festival.id}
+              className="relative"
+              onClick={() => {
+                if (!editMode) router.push(`/festival/${festival.id}`);
+              }}
+            >
+              <FestivalListItem festival={festival} hideLikeButton={true} />
+              {editMode && (
+                <button
+                  onClick={() => toggleSelect(festival.id)}
+                  className="absolute right-2 top-2 w-5 h-5 rounded-full border-2 border-main-100 bg-white flex items-center justify-center"
+                >
+                  {selectedIds.includes(festival.id) && (
+                    <div className="w-3 h-3 rounded-full bg-main-100" />
+                  )}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 하단 삭제 버튼 */}
+      {editMode && (
+        <button
+          onClick={() => setShowDeleteModal(true)}
+          className="fixed bottom-20 left-1/2 -translate-x-1/2 w-[350px] py-2 bg-main-100 text-white rounded-lg text-sm font-medium shadow-md"
+        >
+          {selectedIds.length > 0
+            ? `${selectedIds.length}개 삭제하기`
+            : '삭제할 항목을 선택하세요'}
+        </button>
+      )}
+
+      {/* 삭제 모달 */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center">
+          <div className="bg-white w-[80%] rounded-xl p-6 text-center space-y-4">
+            <p className="text-base font-medium">즐겨찾기를 삭제하시겠어요?</p>
+            <p className="text-sm text-neutral-500">
+              삭제된 즐겨찾기는 복구가 불가능해요!
+            </p>
+            <div className="flex gap-3 mt-4">
+              <button
+                onClick={() => setShowDeleteModal(false)}
+                className="flex-1 py-2 border border-main-100 rounded-md text-main-100"
+              >
+                취소할래요
+              </button>
+              <button
+                onClick={handleDelete}
+                className="flex-1 py-2 bg-main-100 text-white rounded-md"
+              >
+                삭제할래요
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -100,6 +100,9 @@ export default function BookmarkPage() {
               <div
                 key={festival.id}
                 className={` relative rounded-md ${isSelected && editMode ? 'bg-sub-5' : ''}  `}
+                onClick={() => {
+                  if (!editMode) router.push(`/festival/${festival.id}`);
+                }}
               >
                 <FestivalListItem festival={festival} hideLikeButton={true} />
                 {editMode && (

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -111,7 +111,10 @@ export default function BookmarkPage() {
                 <FestivalListItem festival={festival} hideLikeButton={true} />
                 {editMode && (
                   <button
-                    onClick={() => toggleSelect(festival.id)}
+                    onClick={() => {
+                      e.stopPropagation();
+                      toggleSelect(festival.id);
+                    }}
                     className="absolute right-4 top-1.5 text-xl z-10"
                   >
                     <i

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -101,7 +101,11 @@ export default function BookmarkPage() {
                 key={festival.id}
                 className={` relative rounded-md ${isSelected && editMode ? 'bg-sub-5' : ''}  `}
                 onClick={() => {
-                  if (!editMode) router.push(`/festival/${festival.id}`);
+                  if (!editMode) {
+                    router.push(`/festival/${festival.id}`);
+                  } else {
+                    toggleSelect(festival.id);
+                  }
                 }}
               >
                 <FestivalListItem festival={festival} hideLikeButton={true} />

--- a/src/app/festival/bookmarks/page.js
+++ b/src/app/festival/bookmarks/page.js
@@ -92,20 +92,20 @@ export default function BookmarkPage() {
       )}
 
       {bookmarks.length > 0 && (
-        <div className="space-y-4 px-4 pt-3">
+        <div className="space-y-3">
           {bookmarks.map((festival) => {
             const isSelected = selectedIds.includes(festival.id);
 
             return (
               <div
                 key={festival.id}
-                className={` relative rounded-md ${isSelected && editMode ? 'bg-sub-15' : ''} `}
+                className={` relative rounded-md ${isSelected && editMode ? 'bg-sub-5' : ''}  `}
               >
                 <FestivalListItem festival={festival} hideLikeButton={true} />
                 {editMode && (
                   <button
                     onClick={() => toggleSelect(festival.id)}
-                    className="absolute right-2 -top-1 text-xl z-10"
+                    className="absolute right-4 top-1.5 text-xl z-10"
                   >
                     <i
                       className={`${
@@ -136,28 +136,30 @@ export default function BookmarkPage() {
 
       {/* 삭제 모달 */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center">
-          <div className="bg-white w-[75%] max-w-[390px] rounded-xl p-4 text-center shadow-lg">
-            <p className="text-base font-semibold mt-3">
-              즐겨찾기를 삭제하시겠어요?
-            </p>
-            <p className="text-base font-semibold">
-              삭제된 즐겨찾기는 복구가 불가능해요!
-            </p>
-            <div className="flex gap-3 mt-8">
-              <button
-                onClick={() => setShowDeleteModal(false)}
-                className="flex-1 py-2.5 bg-main-5 text-main-100 font-semibold rounded-md shadow-[0_0_3px_rgba(0,0,0,0.1)]"
-              >
-                취소할래요
-              </button>
+        <div className="fixed inset-0 z-50 flex justify-center">
+          <div className="w-full max-w-[390px] bg-black/30 px-4 flex items-center justify-center">
+            <div className="bg-white w-full rounded-xl p-4 text-center shadow-lg">
+              <p className="text-base font-semibold mt-3">
+                즐겨찾기를 삭제하시겠어요?
+              </p>
+              <p className="text-base font-semibold">
+                삭제된 즐겨찾기는 복구가 불가능해요!
+              </p>
+              <div className="flex gap-3 mt-8">
+                <button
+                  onClick={() => setShowDeleteModal(false)}
+                  className="flex-1 py-2.5 bg-main-5 text-main-100 font-semibold rounded-md shadow-[0_0_3px_rgba(0,0,0,0.1)]"
+                >
+                  취소할래요
+                </button>
 
-              <button
-                onClick={handleDelete}
-                className="flex-1 py-2.5 bg-main-100 text-background font-semibold rounded-md"
-              >
-                삭제할래요
-              </button>
+                <button
+                  onClick={handleDelete}
+                  className="flex-1 py-2.5 bg-main-100 text-background font-semibold rounded-md"
+                >
+                  삭제할래요
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/festival/page.js
+++ b/src/app/festival/page.js
@@ -25,7 +25,10 @@ export default function FestivalPage() {
         </div>
 
         <button className="p-1">
-          <GoHeartFill className="text-main-100 w-5 h-5" />
+          <GoHeartFill
+            className="text-main-100 w-5 h-5"
+            onClick={() => router.push(`/festival/bookmarks`)}
+          />
         </button>
       </div>
 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #9
---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
[축제 즐겨찾기 테스트 배포 링크](https://dori-room-git-feature-festival-bookmark-suwiths-projects.vercel.app/festival/bookmarks/)

## 1. 즐겨찾기 페이지 기본 UI 구성
축제 메인페이지 상단 하트 아이콘을 통해 `/festival/bookmarks` 경로에 진입 시 사용자가 저장한 즐겨찾기 축제 목록이 나타나도록 구현했습니다. 목록이 비어있을 경우에는 안내 메시지를 표시하며 편집 버튼을 통해 개별/전체 선택이 가능한 편집 모드로 진입할 수 있습니다. 선택된 아이템은 배경색과 체크 아이콘을 통해 시각적으로 구분됩니다. 검색결과 목록 페이지에서 사용하는 FestivalListItem 컴포넌트를 사용하였는데, 즐겨찾기 페이지에서는 FestivalListItem의 하트 아이콘이 렌더링되지 않도록 hideLikeButton props를 추가하고 관련 기본값 처리 및 예외 상황을 반영했습니다.


---

# 📸 스크린샷
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->
<img width="389" height="949" alt="스크린샷 2025-07-30 오전 2 40 33" src="https://github.com/user-attachments/assets/b27c94e9-b2a6-4469-b5b3-6aba541fc9a2" />
<img width="391" height="948" alt="스크린샷 2025-07-30 오전 2 40 49" src="https://github.com/user-attachments/assets/7edcfbd9-8557-4c57-b072-b13a1cf88594" />
<img width="389" height="947" alt="스크린샷 2025-07-30 오전 2 40 57" src="https://github.com/user-attachments/assets/fd3fcca2-2838-4df6-be3c-6aeb82736ec4" />
<img width="389" height="947" alt="스크린샷 2025-07-30 오전 2 41 42" src="https://github.com/user-attachments/assets/7dede6f8-91f4-4a89-bce3-4482f06b1f9e" />
<img width="388" height="947" alt="스크린샷 2025-07-30 오전 2 41 47" src="https://github.com/user-attachments/assets/718cf339-8a65-4fdf-be0b-bd73cc552928" />

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- PR#6 merge 이후에 리뷰해 주시기 바랍니다.
- 페이지별 하단 네비바 제거 작업 전이라 감안해서 봐주시면 감사하겠습니다!

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?