### PR TITLE
feat: 축제 API 연결

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,12 @@
 /** @type {import('next').NextConfig} */
+
+const url = process.env.NEXT_PUBLIC_API_BASE_URL;
 const nextConfig = {
   async rewrites() {
     return [
       {
         source: '/api/:path*',
-        destination: 'http://43.202.194.181:8080/api/:path*', // 백엔드 HTTP 그대로
+        destination: `${url}/api/:path*`,
       },
     ];
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export', // 정적 SPA로 빌드
   trailingSlash: true,
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  trailingSlash: true,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://43.202.194.181:8080/api/:path*', // 백엔드 HTTP 그대로
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,15 +1,5 @@
 /** @type {import('next').NextConfig} */
-
-const url = process.env.NEXT_PUBLIC_API_BASE_URL;
 const nextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: `${url}/api/:path*`,
-      },
-    ];
-  },
+  trailingSlash: false,
 };
-
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
     "": {
       "name": "doriroom",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@capacitor/android": "^7.4.2",
         "@capacitor/cli": "^7.4.0",
         "@capacitor/core": "^7.4.0",
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",
+        "axios": "^1.11.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "doriroom-image-picker": "file:doriroom-image-picker",
@@ -39,6 +41,9 @@
     "doriroom-image-picker": {
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "rimraf": "^3.0.2"
+      },
       "devDependencies": {
         "@capacitor/android": "^7.0.0",
         "@capacitor/core": "^7.0.0",
@@ -50,7 +55,6 @@
         "eslint": "^8.57.0",
         "prettier": "^3.4.2",
         "prettier-plugin-java": "^2.6.6",
-        "rimraf": "^6.0.1",
         "rollup": "^4.30.1",
         "swiftlint": "^2.0.0",
         "typescript": "~4.1.5"
@@ -138,6 +142,43 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "doriroom-image-picker/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "doriroom-image-picker/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3114,6 +3155,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3149,6 +3196,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3163,7 +3221,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3211,7 +3268,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3274,7 +3330,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3450,6 +3505,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -3463,7 +3530,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -3647,6 +3713,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3691,7 +3766,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3839,7 +3913,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3849,7 +3922,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3887,7 +3959,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3900,7 +3971,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4737,6 +4807,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4781,6 +4871,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
@@ -4823,7 +4929,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -4845,7 +4950,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4886,7 +4990,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4911,7 +5014,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5068,7 +5170,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5146,7 +5247,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5159,7 +5259,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5175,7 +5274,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5226,7 +5324,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6253,7 +6350,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6283,6 +6379,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mingcute_icon": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/mingcute_icon/-/mingcute_icon-2.9.6.tgz",
@@ -6293,7 +6410,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6645,7 +6761,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6788,7 +6903,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6996,6 +7110,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8456,7 +8576,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@capacitor/core": "^7.4.0",
     "@mdi/js": "^7.4.47",
     "@mdi/react": "^1.6.1",
+    "axios": "^1.11.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "doriroom-image-picker": "file:doriroom-image-picker",

--- a/src/app/_providers/AuthBootstrap.js
+++ b/src/app/_providers/AuthBootstrap.js
@@ -32,6 +32,6 @@ export default function AuthBootstrap({ children }) {
     };
   }, [signIn]);
 
-  if (!ready || signingIn) return null; // 필요하면 스켈레톤 표기
+  if (!ready || signingIn) return null;
   return children;
 }

--- a/src/app/_providers/AuthBootstrap.js
+++ b/src/app/_providers/AuthBootstrap.js
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useSignIn from '@/hooks/auth/useSignIn';
+
+function hasTokens() {
+  if (typeof window === 'undefined') return false;
+  const la = localStorage.getItem('access_token');
+  const lr = localStorage.getItem('refresh_token');
+  const sa = sessionStorage.getItem('access_token');
+  const sr = sessionStorage.getItem('refresh_token');
+  return (la && lr) || (sa && sr);
+}
+
+export default function AuthBootstrap({ children }) {
+  const { signIn, signingIn } = useSignIn();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    async function boot() {
+      if (!hasTokens()) {
+        try {
+          await signIn({ remember: true });
+        } catch (_) {}
+      }
+      if (mounted) setReady(true);
+    }
+    boot();
+    return () => {
+      mounted = false;
+    };
+  }, [signIn]);
+
+  if (!ready || signingIn) return null; // 필요하면 스켈레톤 표기
+  return children;
+}

--- a/src/app/api/[...path]/route.js
+++ b/src/app/api/[...path]/route.js
@@ -3,44 +3,58 @@ export const dynamic = 'force-dynamic';
 
 const ORIGIN = process.env.BACKEND_ORIGIN;
 
-function buildTargetUrl(req, pathSegments) {
-  const path = Array.isArray(pathSegments) ? pathSegments.join('/') : '';
-  const url = new URL(req.url);
-  return `${ORIGIN}/api/${path}${url.search || ''}`;
+const SAFE_REQ_HEADERS = [
+  'authorization',
+  'content-type',
+  'accept',
+  'user-agent',
+  'accept-language',
+  'referer',
+  'origin'
+];
+const SAFE_RES_HEADERS = ['content-type', 'cache-control', 'etag', 'last-modified', 'vary'];
+
+const isAscii = (v) => typeof v === 'string' && /^[\x00-\xFF]*$/.test(v);
+
+function buildTargetUrl(req) {
+  const { pathname, search } = req.nextUrl;
+  const pathAfterApi = pathname.replace(/^\/api\//, '');
+  return `${ORIGIN}/api/${pathAfterApi}${search || ''}`;
 }
 
-async function proxy(req, context) {
+async function proxy(req) {
   if (!ORIGIN) return new Response('BACKEND_ORIGIN not set', { status: 500 });
 
-  const params = await context.params;
+  const fwd = new Headers();
+  for (const k of SAFE_REQ_HEADERS) {
+    const v = req.headers.get(k);
+    if (v && isAscii(v)) fwd.set(k, v);
+  }
 
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('x-forwarded-host');
-  headers.delete('x-forwarded-proto');
+  const hostUrl = new URL(ORIGIN);
+  fwd.set('x-forwarded-proto', 'https');
+  fwd.set('x-forwarded-host', req.headers.get('host') || '');
+  fwd.set('host', hostUrl.host);
 
-  // 인증 전달 보강
-  const auth = req.headers.get('authorization');
-  if (auth) headers.set('authorization', auth);
-
-  const init = {
+  const res = await fetch(buildTargetUrl(req), {
     method: req.method,
-    headers,
+    headers: fwd,
     body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-    cache: 'no-store',
-  };
+    cache: 'no-store'
+  });
 
-  const target = buildTargetUrl(req, params?.path);
-  const res = await fetch(target, init);
+  const out = new Headers();
+  for (const k of SAFE_RES_HEADERS) {
+    const v = res.headers.get(k);
+    if (v && isAscii(v)) out.set(k, v);
+  }
 
-  const buf = await res.arrayBuffer();
-  const outHeaders = new Headers(res.headers);
-  return new Response(buf, { status: res.status, headers: outHeaders });
+  return new Response(res.body, { status: res.status, headers: out });
 }
 
-export async function GET(req, ctx)     { return proxy(req, ctx); }
-export async function POST(req, ctx)    { return proxy(req, ctx); }
-export async function PUT(req, ctx)     { return proxy(req, ctx); }
-export async function PATCH(req, ctx)   { return proxy(req, ctx); }
-export async function DELETE(req, ctx)  { return proxy(req, ctx); }
-export async function OPTIONS(req, ctx) { return proxy(req, ctx); }
+export async function GET(req)    { return proxy(req); }
+export async function POST(req)   { return proxy(req); }
+export async function PUT(req)    { return proxy(req); }
+export async function PATCH(req)  { return proxy(req); }
+export async function DELETE(req) { return proxy(req); }
+export async function OPTIONS(req){ return proxy(req); }

--- a/src/app/api/[...path]/route.js
+++ b/src/app/api/[...path]/route.js
@@ -1,0 +1,46 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ORIGIN = process.env.BACKEND_ORIGIN;
+
+function buildTargetUrl(req, pathSegments) {
+  const path = Array.isArray(pathSegments) ? pathSegments.join('/') : '';
+  const url = new URL(req.url);
+  return `${ORIGIN}/api/${path}${url.search || ''}`;
+}
+
+async function proxy(req, context) {
+  if (!ORIGIN) return new Response('BACKEND_ORIGIN not set', { status: 500 });
+
+  const params = await context.params;
+
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('x-forwarded-host');
+  headers.delete('x-forwarded-proto');
+
+  // 인증 전달 보강
+  const auth = req.headers.get('authorization');
+  if (auth) headers.set('authorization', auth);
+
+  const init = {
+    method: req.method,
+    headers,
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+    cache: 'no-store',
+  };
+
+  const target = buildTargetUrl(req, params?.path);
+  const res = await fetch(target, init);
+
+  const buf = await res.arrayBuffer();
+  const outHeaders = new Headers(res.headers);
+  return new Response(buf, { status: res.status, headers: outHeaders });
+}
+
+export async function GET(req, ctx)     { return proxy(req, ctx); }
+export async function POST(req, ctx)    { return proxy(req, ctx); }
+export async function PUT(req, ctx)     { return proxy(req, ctx); }
+export async function PATCH(req, ctx)   { return proxy(req, ctx); }
+export async function DELETE(req, ctx)  { return proxy(req, ctx); }
+export async function OPTIONS(req, ctx) { return proxy(req, ctx); }

--- a/src/app/diary/write/_components/SelectDate.js
+++ b/src/app/diary/write/_components/SelectDate.js
@@ -4,7 +4,7 @@ import DayPicker from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
 import React from 'react';
 
-export default function SelectDate({ open, selectedDate, onSelect, onClose }) {
+export default function SelectDate({ selectedDate, onSelect, onClose }) {
   return (
     <div
       className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto z-100 bg-background rounded-t-xl px-4 py-4`}

--- a/src/app/diary/write/_components/SelectDate.js
+++ b/src/app/diary/write/_components/SelectDate.js
@@ -12,7 +12,7 @@ export default function SelectDate({ selectedDate, onSelect, onClose }) {
       <div className="w-full text-right mb-1">
         <button
           onClick={onClose}
-          className="bg-main-5 bg-opacity-50 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
+          className="bg-main-5 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
         >
           <i className="mgc_close_line" />
         </button>

--- a/src/app/diary/write/_components/SelectDate.js
+++ b/src/app/diary/write/_components/SelectDate.js
@@ -2,20 +2,19 @@
 
 import DayPicker from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
+import React from 'react';
 
 export default function SelectDate({ open, selectedDate, onSelect, onClose }) {
   return (
     <div
-      className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto z-100 bg-background rounded-t-xl px-4 py-8 transition-transform duration-300 ease-in-out ${
-        open ? 'translate-y-0' : 'translate-y-full'
-      }`}
+      className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto z-100 bg-background rounded-t-xl px-4 py-4`}
     >
       <div className="w-full text-right mb-1">
         <button
           onClick={onClose}
-          className=" bg-main-5 bg-opacity-50 text-main-40 rounded-full w-5 h-5 text-xs"
+          className="bg-main-5 bg-opacity-50 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
         >
-          ✕
+          <i className="mgc_close_line" />
         </button>
       </div>
 

--- a/src/app/diary/write/page.js
+++ b/src/app/diary/write/page.js
@@ -233,15 +233,16 @@ export default function DiaryWrite() {
                         alt={`selected-${i}`}
                         className="object-cover w-full h-full"
                       />
+
                       <button
                         onClick={() =>
                           setImages((prev) =>
                             prev.filter((_, idx) => idx !== i)
                           )
                         }
-                        className="absolute top-1.5 right-1.5 bg-main-5 bg-opacity-50 text-main-40 rounded-full w-5 h-5 text-xs"
+                        className="bg-main-5 bg-opacity-50 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
                       >
-                        ✕
+                        <i className="mgc_close_line" />
                       </button>
                     </>
                   ) : null}
@@ -343,7 +344,7 @@ export default function DiaryWrite() {
         <div className="fixed top-0 bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] bg-black/25 z-99" />
       )}
       <div
-        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto z-100 bg-white rounded-t-xl px-4 py-8 transition-transform duration-300 ease-in-out ${
+        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto z-100 transition-transform duration-300 ease-in-out ${
           showCalendar ? 'translate-y-0' : 'translate-y-full'
         }`}
       >

--- a/src/app/festival/[festivalId]/page.js
+++ b/src/app/festival/[festivalId]/page.js
@@ -1,17 +1,21 @@
-import { mockFestivals } from '../mockData';
-import FestivalDetail from '../_components/FestivalDetail';
+'use client';
 
-export function generateStaticParams() {
-  return mockFestivals.map((festival) => ({
-    festivalId: festival.id.toString(),
-  }));
-}
+import { useParams } from 'next/navigation';
+import useFestivalDetail from '@/hooks/festival/useFestivalDetail';
+import FestivalDetail from '@/app/festival/_components/FestivalDetail';
 
-export default async function Page({ params }) {
-  const { festivalId } = await params;
-  const festival = mockFestivals.find((f) => f.id === Number(festivalId));
+export default function FestivalPage() {
+  const params = useParams(); // { festivalId: '...' } 형태
+  const festivalId = Array.isArray(params.festivalId)
+    ? params.festivalId[0]
+    : params.festivalId;
 
-  if (!festival) return <div>존재하지 않는 축제입니다.</div>;
+  const { festival, loading, error } = useFestivalDetail(festivalId);
+
+  if (!festivalId) return <div className="p-4">잘못된 접근입니다.</div>;
+  if (loading) return <div className="p-4">로딩 중...</div>;
+  if (error) return <div className="p-4">에러가 발생했습니다.</div>;
+  if (!festival) return <div className="p-4">존재하지 않는 축제입니다.</div>;
 
   return <FestivalDetail festival={festival} />;
 }

--- a/src/app/festival/_components/FestivalCard.js
+++ b/src/app/festival/_components/FestivalCard.js
@@ -36,20 +36,20 @@ export default function FestivalCard({ festival }) {
 
       <div className="py-2 text-[10px]">
         <div className="flex flex-wrap gap-1 mt-0.5">
-          <span className="text-main-100 bg-main-5 px-1 rounded-xl">
+          <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
             {festival.region.slice(0, 2)}
           </span>
-          <span className="text-main-100 bg-main-5 px-1 rounded-full">
+          <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
             {festival.category}
           </span>
           {/*{festival.reviews.length > 0 && (*/}
-          {/*  <span className="text-main-100 bg-main-5 px-1 rounded-full">*/}
+          {/*  <span className="text-main-100 bg-main-5 px-1 rounded-lg">*/}
           {/*    후기 {festival.reviews.length}개*/}
           {/*  </span>*/}
           {/*)}*/}
 
           {festival.price === '무료' && (
-            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+            <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
               무료
             </span>
           )}

--- a/src/app/festival/_components/FestivalCard.js
+++ b/src/app/festival/_components/FestivalCard.js
@@ -37,7 +37,7 @@ export default function FestivalCard({ festival }) {
       <div className="py-2 text-[10px]">
         <div className="flex flex-wrap gap-1 mt-0.5">
           <span className="text-main-100 bg-main-5 px-1 rounded-xl">
-            {festival.region}
+            {festival.region.slice(0, 2)}
           </span>
           <span className="text-main-100 bg-main-5 px-1 rounded-full">
             {festival.category}
@@ -47,9 +47,12 @@ export default function FestivalCard({ festival }) {
           {/*    후기 {festival.reviews.length}개*/}
           {/*  </span>*/}
           {/*)}*/}
-          {/*<span className="text-main-100 bg-main-5 px-1 rounded-full">*/}
-          {/*  {festival.price === 0 ? '무료' : '유료'}*/}
-          {/*</span>*/}
+
+          {festival.price === '무료' && (
+            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+              무료
+            </span>
+          )}
         </div>
         <div className="font-bold text-sm mt-1.5 truncate">
           {festival.title}

--- a/src/app/festival/_components/FestivalCard.js
+++ b/src/app/festival/_components/FestivalCard.js
@@ -42,14 +42,14 @@ export default function FestivalCard({ festival }) {
           <span className="text-main-100 bg-main-5 px-1 rounded-full">
             {festival.category}
           </span>
-          {festival.reviews.length > 0 && (
-            <span className="text-main-100 bg-main-5 px-1 rounded-full">
-              후기 {festival.reviews.length}개
-            </span>
-          )}
-          <span className="text-main-100 bg-main-5 px-1 rounded-full">
-            {festival.price === 0 ? '무료' : '유료'}
-          </span>
+          {/*{festival.reviews.length > 0 && (*/}
+          {/*  <span className="text-main-100 bg-main-5 px-1 rounded-full">*/}
+          {/*    후기 {festival.reviews.length}개*/}
+          {/*  </span>*/}
+          {/*)}*/}
+          {/*<span className="text-main-100 bg-main-5 px-1 rounded-full">*/}
+          {/*  {festival.price === 0 ? '무료' : '유료'}*/}
+          {/*</span>*/}
         </div>
         <div className="font-bold text-sm mt-1.5 truncate">
           {festival.title}

--- a/src/app/festival/_components/FestivalDetail.js
+++ b/src/app/festival/_components/FestivalDetail.js
@@ -122,9 +122,20 @@ export default function FestivalDetail({ festival }) {
         </div>
         <div className="flex flex-row items-center gap-3 text-sm">
           <p className="text-neutral-500">일자</p>
-          <span className="text-main-100 bg-main-5 rounded-full px-1.5 py-0.5 flex items-center font-normal text-[11px]">
+          <span
+            className={`rounded-full px-1.5 py-0.5 flex items-center font-normal text-[11px] ${
+              festival.status === '진행 예정'
+                ? 'bg-main-5 text-main-100'
+                : festival.status === '진행 중'
+                  ? 'bg-sub-5 text-sub-100'
+                  : festival.status === '행사 종료'
+                    ? 'bg-neutral-100 text-neutral-300'
+                    : ''
+            }`}
+          >
             {festival.status}
           </span>
+
           <span>
             {festival.startDate} ~ {festival.endDate}
           </span>
@@ -132,7 +143,9 @@ export default function FestivalDetail({ festival }) {
         <div className="flex flex-row items-center gap-3 text-sm">
           <p className="text-neutral-500">시간</p>
           <span>
-            {festival.startTime} ~ {festival.endTime}
+            {festival.startTime === ''
+              ? '-'
+              : `${festival.startTime} ~ ${festival.endTime}`}
           </span>
         </div>
         <div className="flex flex-row items-center gap-3 text-sm">
@@ -148,7 +161,7 @@ export default function FestivalDetail({ festival }) {
           <p>
             {festival.price === 0
               ? '무료'
-              : `₩${festival.price.toLocaleString()}`}
+              : `${festival.price.toLocaleString()}`}
           </p>
         </div>
       </div>
@@ -179,20 +192,34 @@ export default function FestivalDetail({ festival }) {
       {/* 설명 탭 */}
       {activeTab === '설명' && (
         <div className="px-4 py-6 space-y-6 text-sm text-neutral-800">
-          {festival.details?.map((detail, idx) => (
-            <div key={idx}>
-              <div className="text-main-100 font-medium mb-1 flex items-center gap-1">
-                <Icon path={mdiTree} className="w-4 h-4 text-main-100" />
-                {detail.infoname}
-              </div>
-              <p
-                className="text-neutral-600 leading-relaxed"
-                dangerouslySetInnerHTML={{
-                  __html: detail.infotext.replace(/\n/g, '<br />'),
-                }}
-              />
+          <div>
+            <img src={festival.thumbnail} />
+          </div>
+
+          <div>
+            <div className="text-main-100 font-medium mb-1 flex items-center gap-1">
+              <Icon path={mdiTree} className="w-4 h-4 text-main-100" />
+              행사소개
             </div>
-          ))}
+            <p
+              className="text-neutral-600 leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: festival.eventIntro.replace(/\n/g, '<br />'),
+              }}
+            />{' '}
+          </div>
+          <div>
+            <div className="text-main-100 font-medium mb-1 flex items-center gap-1">
+              <Icon path={mdiTree} className="w-4 h-4 text-main-100" />
+              행사내용
+            </div>
+            <p
+              className="text-neutral-600 leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: festival.eventContent.replace(/\n/g, '<br />'),
+              }}
+            />{' '}
+          </div>
         </div>
       )}
 

--- a/src/app/festival/_components/FestivalDetail.js
+++ b/src/app/festival/_components/FestivalDetail.js
@@ -140,7 +140,7 @@ export default function FestivalDetail({ festival }) {
             {festival.startDate} ~ {festival.endDate}
           </span>
         </div>
-        <div className="flex flex-row items-center gap-3 text-sm">
+        <div className="flex flex-row gap-3 text-sm">
           <p className="text-neutral-500">시간</p>
           <span>
             {festival.startTime === ''
@@ -148,21 +148,21 @@ export default function FestivalDetail({ festival }) {
               : `${festival.startTime} ~ ${festival.endTime}`}
           </span>
         </div>
-        <div className="flex flex-row items-center gap-3 text-sm">
+        <div className="flex flex-row gap-3 text-sm">
           <p className=" text-neutral-500">위치</p>
           <p>{festival.location}</p>
         </div>
-        <div className="flex flex-row items-center gap-3 text-sm">
+        <div className="flex flex-row gap-3 text-sm">
           <p className=" text-neutral-500">주최기관</p>
           <p>{festival.host}</p>
         </div>
-        <div className="flex flex-row items-center gap-3 text-sm">
+        <div className="flex flex-row gap-3 text-sm">
           <p className=" text-neutral-500">금액</p>
-          <p>
-            {festival.price === 0
-              ? '무료'
-              : `${festival.price.toLocaleString()}`}
-          </p>
+          <p
+            dangerouslySetInnerHTML={{
+              __html: festival.price.replace(/\n/g, '<br />'),
+            }}
+          />
         </div>
       </div>
       <div className="mt-1 w-full h-1.5 p-0 bg-neutral-100"></div>

--- a/src/app/festival/_components/FestivalDetail.js
+++ b/src/app/festival/_components/FestivalDetail.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { GoHeart, GoHeartFill } from 'react-icons/go';
 import Icon from '@mdi/react';
 import { mdiTree } from '@mdi/js';
@@ -19,6 +19,11 @@ export default function FestivalDetail({ festival }) {
   const [likedReviews, setLikedReviews] = useState([]);
   const [reviewSort, setReviewSort] = useState('latest');
   const [showToast, setShowToast] = useState(false);
+
+  // 헤더 전환 상태
+  const [isScrolled, setIsScrolled] = useState(false);
+  const sentinelRef = useRef(null);
+  const HEADER_H = 70; // 헤더 높이(px): h-12(=48) + 상단 패딩 보정 등이 있으면 맞춰 조정
 
   const handleLike = () => {
     setLiked((prev) => !prev);
@@ -44,19 +49,55 @@ export default function FestivalDetail({ festival }) {
     return () => clearTimeout(timer);
   }, []);
 
+  // 이미지 하단 센티넬이 헤더 뒤로 넘어가면 isScrolled = true
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        // entry가 보이면 아직 이미지 영역, 안 보이면 정보 영역
+        setIsScrolled(!entry.isIntersecting);
+      },
+      {
+        root: null,
+        threshold: 0,
+        // 헤더 높이만큼 위쪽을 미리 깎아, 헤더와 정확히 맞닿을 때 전환되게 함
+        rootMargin: `-${HEADER_H}px 0px 0px 0px`,
+      }
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
   return (
-    <div className="max-w-[390px] mx-auto bg-[#FEFEFE] min-h-screen pb-10">
-      {/* 이미지 상단 */}
+    <div className="max-w-[390px] w-screen min-h-screen pb-10">
+      {/* 고정 헤더: 가운데 정렬 + 전환 애니메이션 */}
+      <div
+        className={`fixed top-0 left-1/2 -translate-x-1/2 w-full pt-[50px] max-w-[390px] z-50 transition-colors duration-300 ${
+          isScrolled ? 'bg-background' : 'bg-transparent'
+        }`}
+      >
+        <div className="flex items-center h-12 px-3">
+          <BackButton
+            color={isScrolled ? 'text-neutral-500' : 'text-background'}
+            isShadow={true}
+          />
+        </div>
+      </div>
+
+      {/* 썸네일 */}
       <div className="relative">
         <img
           src={festival.thumbnail}
           alt={festival.title}
           className="w-full h-[370px] object-cover"
         />
-        <div className="absolute top-10 left-3">
-          <BackButton color={'text-background'} isShadow={true} />
-        </div>
       </div>
+
+      {/* 이미지 바로 아래 센티넬: 이 지점이 헤더 뒤로 넘어갈 때 배경/아이콘 색 전환 */}
+      <div ref={sentinelRef} className="h-px" />
 
       {/* 정보 */}
       <div className="px-4 py-3 space-y-2">

--- a/src/app/festival/_components/FestivalDetail.js
+++ b/src/app/festival/_components/FestivalDetail.js
@@ -153,7 +153,7 @@ export default function FestivalDetail({ festival }) {
           <p>{festival.location}</p>
         </div>
         <div className="flex flex-row gap-3 text-sm">
-          <p className=" text-neutral-500">주최기관</p>
+          <p className=" text-neutral-500">주최</p>
           <p>{festival.host}</p>
         </div>
         <div className="flex flex-row gap-3 text-sm">
@@ -193,7 +193,7 @@ export default function FestivalDetail({ festival }) {
       {activeTab === '설명' && (
         <div className="px-4 py-6 space-y-6 text-sm text-neutral-800">
           <div>
-            <img src={festival.thumbnail} />
+            <img src={festival.thumbnail} alt={festival.title} />
           </div>
 
           <div>

--- a/src/app/festival/_components/FestivalDetail.js
+++ b/src/app/festival/_components/FestivalDetail.js
@@ -121,24 +121,26 @@ export default function FestivalDetail({ festival }) {
           </div>
         </div>
         <div className="flex flex-row items-center gap-3 text-sm">
-          <p className="text-neutral-500">일자</p>
-          <span
-            className={`rounded-full px-1.5 py-0.5 flex items-center font-normal text-[11px] ${
-              festival.status === '진행 예정'
-                ? 'bg-main-5 text-main-100'
-                : festival.status === '진행 중'
-                  ? 'bg-sub-5 text-sub-100'
-                  : festival.status === '행사 종료'
-                    ? 'bg-neutral-100 text-neutral-300'
-                    : ''
-            }`}
-          >
-            {festival.status}
-          </span>
-
-          <span>
-            {festival.startDate} ~ {festival.endDate}
-          </span>
+          <p className="text-neutral-500 whitespace-nowrap">일자</p>
+          <div className="flex flex-row gap-2 items-center">
+            {' '}
+            <span
+              className={`px-1.5 py-[1.8px] rounded-sm flex items-center font-normal text-[11px] ${
+                festival.status === '진행 예정'
+                  ? 'bg-main-5 text-main-100'
+                  : festival.status === '진행 중'
+                    ? 'bg-sub-5 text-sub-100'
+                    : festival.status === '행사 종료'
+                      ? 'bg-neutral-100 text-neutral-300'
+                      : ''
+              }`}
+            >
+              {festival.status}
+            </span>
+            <span>
+              {festival.startDate} ~ {festival.endDate}
+            </span>{' '}
+          </div>
         </div>
         <div className="flex flex-row gap-3 text-sm">
           <p className="text-neutral-500">시간</p>
@@ -149,15 +151,15 @@ export default function FestivalDetail({ festival }) {
           </span>
         </div>
         <div className="flex flex-row gap-3 text-sm">
-          <p className=" text-neutral-500">위치</p>
+          <p className=" text-neutral-500 whitespace-nowrap">위치</p>
           <p>{festival.location}</p>
         </div>
         <div className="flex flex-row gap-3 text-sm">
-          <p className=" text-neutral-500">주최</p>
+          <p className=" text-neutral-500 whitespace-nowrap">주최</p>
           <p>{festival.host}</p>
         </div>
         <div className="flex flex-row gap-3 text-sm">
-          <p className=" text-neutral-500">금액</p>
+          <p className=" text-neutral-500 whitespace-nowrap">금액</p>
           <p
             dangerouslySetInnerHTML={{
               __html: festival.price.replace(/\n/g, '<br />'),

--- a/src/app/festival/_components/FestivalListItem.js
+++ b/src/app/festival/_components/FestivalListItem.js
@@ -64,20 +64,23 @@ export default function FestivalListItem({
       <div className="flex flex-col justify-between flex-1 pr-1">
         <div>
           <div className="flex flex-wrap gap-1 mb-1 text-[11px]">
-            <span className="text-main-100 bg-main-5 px-1 rounded-full">
-              {festival.region}
+            <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
+              {festival.region.slice(0, 2)}
             </span>
-            <span className="text-main-100 bg-main-5 px-1 rounded-full">
+            <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
               {festival.category}
             </span>
-            {festival.reviews.length > 0 && (
-              <span className="text-main-100 bg-main-5 px-1 rounded-full">
-                후기 {festival.reviews.length}개
+            {/*{festival.reviews.length > 0 && (*/}
+            {/*  <span className="text-main-100 bg-main-5 px-1 rounded-lg">*/}
+            {/*    후기 {festival.reviews.length}개*/}
+            {/*  </span>*/}
+            {/*)}*/}
+
+            {festival.price === '무료' && (
+              <span className="text-main-100 bg-main-5 px-1 py-[1px] rounded-sm">
+                무료
               </span>
             )}
-            <span className="text-main-100 bg-main-5 px-1 rounded-full">
-              {festival.price === 0 ? '무료' : '유료'}
-            </span>
           </div>
 
           <div className="font-bold text-sm mt-1.5 truncate">

--- a/src/app/festival/_components/SearchInputBar.js
+++ b/src/app/festival/_components/SearchInputBar.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import BackButton from '../../_components/BackButton';
 import 'mingcute_icon/font/Mingcute.css';
 
@@ -39,13 +39,13 @@ export default function SearchInputBar({
           placeholder="방문하고 싶은 축제를 검색해 보세요!"
           className="w-full bg-neutral-100 px-9 py-2 rounded-lg text-sm outline-none text-neutral-900 placeholder:text-[13px] placeholder:text-neutral-500"
         />
-        <i className="mgc_search_2_fill text-lg text-neutral-400 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+        <i className="mgc_search_2_fill text-lg text-neutral-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
         {value && (
           <button
             onClick={onClear}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-400 text-sm"
+            className="bg-neutral-200 text-neutral-500 rounded-full w-4 h-4 text-xs flex items-center justify-center absolute right-3 top-1/2 -translate-y-1/2 "
           >
-            ✕
+            <i className="mgc_close_line" />
           </button>
         )}
       </div>

--- a/src/app/festival/page.js
+++ b/src/app/festival/page.js
@@ -6,14 +6,16 @@ import RegionFilter from './_components/RegionFilter';
 import FestivalCardListSection from './_components/FestivalCardListSection';
 import 'mingcute_icon/font/Mingcute.css';
 import { mockFestivals } from './mockData';
+import useMainFestivals from '@/hooks/festival/useMainFestivals';
 
 export default function FestivalPage() {
   const router = useRouter();
+  const { upcoming, endingSoon, loading, error } = useMainFestivals();
 
   return (
-    <div className="pb-24 max-w-[390px] mx-auto">
+    <div className="pb-24 pt-[50px] max-w-[390px] ">
       {/* 상단 검색바 + 하트 */}
-      <div className="flex items-center gap-1 px-4 pt-4">
+      <div className="flex items-center gap-1 px-4">
         <div
           onClick={() => router.push('/festival/search')}
           className="flex items-center flex-grow bg-neutral-100 px-4 py-2 rounded-lg text-sm cursor-pointer"
@@ -43,18 +45,22 @@ export default function FestivalPage() {
       </div>
 
       {/* 섹션 */}
-      <FestivalCardListSection
-        title="지금 뜨는 축제 🔥"
-        festivals={mockFestivals}
-      />
-      <FestivalCardListSection
-        title="따끈따끈 신규 축제 🌟"
-        festivals={mockFestivals}
-      />
-      <FestivalCardListSection
-        title="곧 있으면 끝나요! 마감 임박 축제 🚨"
-        festivals={mockFestivals}
-      />
+      {!loading && !error && (
+        <>
+          <FestivalCardListSection
+            title="지금 뜨는 축제 🔥"
+            festivals={mockFestivals}
+          />
+          <FestivalCardListSection
+            title="따끈따끈 신규 축제 🌟"
+            festivals={upcoming}
+          />
+          <FestivalCardListSection
+            title="곧 있으면 끝나요! 마감 임박 축제 🚨"
+            festivals={endingSoon}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/festival/search/_components/BottomSheet.js
+++ b/src/app/festival/search/_components/BottomSheet.js
@@ -15,7 +15,7 @@ export default function BottomSheet({
       <div
         className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto bg-background rounded-t-xl px-4 py-5`}
       >
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between mb-6">
           <h3 className="text-lg font-semibold">{title}</h3>
           <button onClick={onClose} className="p-1"></button>
           <button

--- a/src/app/festival/search/_components/BottomSheet.js
+++ b/src/app/festival/search/_components/BottomSheet.js
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+
+export default function BottomSheet({
+  open,
+  title,
+  onClose,
+  children,
+  footer,
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0">
+      <div
+        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] mx-auto bg-background rounded-t-xl px-4 py-5`}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <button onClick={onClose} className="p-1"></button>
+          <button
+            onClick={onClose}
+            className="bg-main-5 bg-opacity-50 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
+          >
+            <i className="mgc_close_line" />
+          </button>
+        </div>
+        <div className="max-h-[55vh] overflow-auto">{children}</div>
+        {footer ? <div className="mt-3">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/festival/search/_components/BottomSheet.js
+++ b/src/app/festival/search/_components/BottomSheet.js
@@ -20,7 +20,7 @@ export default function BottomSheet({
           <button onClick={onClose} className="p-1"></button>
           <button
             onClick={onClose}
-            className="bg-main-5 bg-opacity-50 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
+            className="bg-main-5 text-main-100 rounded-full w-5 h-5 p-1 text-xs"
           >
             <i className="mgc_close_line" />
           </button>

--- a/src/app/festival/search/_components/CategoryFilter.js
+++ b/src/app/festival/search/_components/CategoryFilter.js
@@ -1,16 +1,22 @@
 'use client';
 
 import BottomSheet from './BottomSheet';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function CategoryFilter({
   open,
   onClose,
   value = [],
   onChange,
-  options,
+  options = [],
 }) {
   const [temp, setTemp] = useState(value);
+
+  // 바텀시트 열릴 때마다 현재 값으로 리셋
+  useEffect(() => {
+    if (open) setTemp(value);
+  }, [open, value]);
+
   const toggle = (k) => {
     setTemp((prev) =>
       prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
@@ -23,15 +29,18 @@ export default function CategoryFilter({
       onClose={onClose}
       title="분야"
       footer={
-        <div className="flex gap-2 font-semibold pb-3">
+        <div className="flex items-center gap-2 pb-3">
           <button
-            className="flex-1 py-3 rounded-md bg-main-15 text-main-100"
+            type="button"
+            className="px-4 py-3 rounded-md bg-main-15 text-main-100 font-semibold shrink-0"
             onClick={() => setTemp([])}
           >
             초기화
           </button>
+
           <button
-            className="flex-4 py-3 rounded-md bg-main-100 text-white"
+            type="button"
+            className="flex-1 py-3 rounded-md bg-main-100 text-white font-semibold"
             onClick={() => {
               onChange(temp);
               onClose();
@@ -42,16 +51,30 @@ export default function CategoryFilter({
         </div>
       }
     >
-      <div className="flex flex-wrap gap-2">
+      <div className="grid grid-cols-2 gap-2 mb-6">
         {options.map((c) => {
           const active = temp.includes(c);
           return (
             <button
+              type="button"
               key={c}
               onClick={() => toggle(c)}
-              className={`px-3 py-1 rounded-full border text-sm ${active ? 'bg-main-5 border-main-100 text-main-100' : 'border-neutral-200'}`}
+              className={[
+                'h-12 w-full rounded-lg px-4',
+                'flex items-center justify-between text-[15px]',
+                active
+                  ? 'bg-main-5 0 text-main-100'
+                  : 'bg-neutral-100  text-neutral-800',
+              ].join(' ')}
             >
-              {c}
+              <span className="truncate">{c}</span>
+
+              {/* 우측 체크 인디케이터 */}
+              <span className="ml-3 inline-flex items-center justify-center">
+                <i
+                  className={`mgc_check_fill  text-xl ${active ? 'text-main-100' : 'text-neutral-300'}`}
+                />
+              </span>
             </button>
           );
         })}

--- a/src/app/festival/search/_components/CategoryFilter.js
+++ b/src/app/festival/search/_components/CategoryFilter.js
@@ -1,0 +1,61 @@
+'use client';
+
+import BottomSheet from './BottomSheet';
+import { useState } from 'react';
+
+export default function CategoryFilter({
+  open,
+  onClose,
+  value = [],
+  onChange,
+  options,
+}) {
+  const [temp, setTemp] = useState(value);
+  const toggle = (k) => {
+    setTemp((prev) =>
+      prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
+    );
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="분야"
+      footer={
+        <div className="flex gap-2 font-semibold pb-3">
+          <button
+            className="flex-1 py-3 rounded-md bg-main-15 text-main-100"
+            onClick={() => setTemp([])}
+          >
+            초기화
+          </button>
+          <button
+            className="flex-4 py-3 rounded-md bg-main-100 text-white"
+            onClick={() => {
+              onChange(temp);
+              onClose();
+            }}
+          >
+            총 {temp.length}개 결과 보기
+          </button>
+        </div>
+      }
+    >
+      <div className="flex flex-wrap gap-2">
+        {options.map((c) => {
+          const active = temp.includes(c);
+          return (
+            <button
+              key={c}
+              onClick={() => toggle(c)}
+              className={`px-3 py-1 rounded-full border text-sm ${active ? 'bg-main-5 border-main-100 text-main-100' : 'border-neutral-200'}`}
+            >
+              {c}
+            </button>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/festival/search/_components/DateFilter.js
+++ b/src/app/festival/search/_components/DateFilter.js
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import BottomSheet from './BottomSheet';
+
+// 월요일 시작 달력 그리드
+function getMonthDaysMonStart(year, month) {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const days = [];
+  for (let i = 1; i <= last.getDate(); i++) days.push(new Date(year, month, i));
+  const lead = (first.getDay() + 6) % 7; // Sun(0) -> 6, Mon(1) -> 0
+  const padStart = Array(lead).fill(null);
+  return [...padStart, ...days];
+}
+
+export default function DateFilter({
+  open,
+  onClose,
+  value = { start: null, end: null },
+  onChange,
+  resultCount, // 선택: 오른쪽 버튼에 갯수 표시
+}) {
+  const now = new Date();
+  const [ym, setYm] = useState({ y: now.getFullYear(), m: now.getMonth() });
+  const [temp, setTemp] = useState(value);
+
+  // 시트 열릴 때마다 외부 value 동기화
+  useEffect(() => {
+    if (!open) return;
+    setTemp({
+      start: value?.start ? new Date(value.start) : null,
+      end: value?.end ? new Date(value.end) : null,
+    });
+    const base = value?.start ?? value?.end ?? now;
+    setYm({ y: base.getFullYear(), m: base.getMonth() });
+  }, [open]); // eslint-disable-line
+
+  const grid = useMemo(() => getMonthDaysMonStart(ym.y, ym.m), [ym]);
+
+  const sameDay = (a, b) =>
+    a &&
+    b &&
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+
+  // 클릭 로직: 단일 선택 허용 + 같은 날짜 두 번 클릭 방지
+  const pick = (day) => {
+    if (!day) return;
+    const start = temp?.start ? new Date(temp.start) : null;
+    const end = temp?.end ? new Date(temp.end) : null;
+
+    // 1) 아직 시작이 없거나(단일/새 선택 시작) 이미 범위가 끝난 상태면 -> start만 설정, end 비움
+    if (!start || (start && end)) {
+      setTemp({ start: day, end: null });
+      return;
+    }
+
+    // 2) 시작만 있는 상태
+    if (start && !end) {
+      if (sameDay(day, start)) {
+        // 같은 날짜 두 번 클릭: 아무것도 하지 않음 (end를 동일 날짜로 잡지 않음)
+        return;
+      }
+      if (day < start) {
+        // 더 이른 날짜를 누르면 start를 갱신(단일 선택 유지)
+        setTemp({ start: day, end: null });
+      } else {
+        // 더 늦은 날짜면 범위 완료
+        setTemp({ start, end: day });
+      }
+    }
+  };
+
+  const fmt = (d) => (d ? d.toISOString().slice(0, 10) : '');
+
+  const inRange = (d) => {
+    if (!d || !temp?.start || !temp?.end) return false;
+    const s = new Date(temp.start);
+    const e = new Date(temp.end);
+    s.setHours(0, 0, 0, 0);
+    e.setHours(0, 0, 0, 0);
+    const x = new Date(d);
+    x.setHours(0, 0, 0, 0);
+    return x >= s && x <= e;
+  };
+
+  const isStart = (d) => d && temp?.start && fmt(d) === fmt(temp.start);
+  const isEnd = (d) => d && temp?.end && fmt(d) === fmt(temp.end);
+
+  // 단일 선택 허용: start만 있어도 적용 가능
+  const canApply = !!temp?.start;
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="기간"
+      footer={
+        <div className="flex gap-2 font-semibold pb-3">
+          <button
+            className="flex-1 py-3 rounded-md bg-main-15 text-main-100"
+            onClick={() => setTemp({ start: null, end: null })}
+          >
+            초기화
+          </button>
+          <button
+            className="flex-4 py-3 rounded-md bg-main-100 text-white"
+            onClick={() => {
+              onChange(temp);
+              onClose();
+            }}
+          >
+            {typeof resultCount === 'number'
+              ? `총 ${resultCount}개 결과 보기`
+              : '적용'}
+          </button>
+        </div>
+      }
+    >
+      {/* 월 네비게이션 */}
+      <div className="flex items-center justify-center mb-3">
+        <button
+          onClick={() =>
+            setYm((p) => ({
+              y: p.m === 0 ? p.y - 1 : p.y,
+              m: p.m === 0 ? 11 : p.m - 1,
+            }))
+          }
+          className="p-2 rounded-md"
+          aria-label="이전 달"
+        >
+          <i className="mgc_left_small_fill text-2xl text-neutral-500" />
+        </button>
+        <div className="font-medium">
+          {ym.y}년 {ym.m + 1}월
+        </div>
+        <button
+          onClick={() =>
+            setYm((p) => ({
+              y: p.m === 11 ? p.y + 1 : p.y,
+              m: p.m === 11 ? 0 : p.m + 1,
+            }))
+          }
+          className="p-2 rounded-md"
+          aria-label="다음 달"
+        >
+          <i className="mgc_right_small_fill text-2xl text-neutral-500" />
+        </button>
+      </div>
+
+      {/* 요일 헤더: 월~일 */}
+      <div className="grid grid-cols-7 gap-1 text-center text-sm mb-4 place-items-center">
+        {['월', '화', '수', '목', '금', '토', '일'].map((d) => (
+          <div key={d} className="w-10 text-neutral-500">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* 날짜 그리드 */}
+      <div className="grid grid-cols-7 gap-y-3 text-center text-sm place-items-stretch mb-6">
+        {grid.map((d, idx) => {
+          const selectedStart = isStart(d);
+          const selectedEnd = isEnd(d);
+          const inSelRange = inRange(d);
+
+          const isColStart = idx % 7 === 0;
+          const isColEnd = idx % 7 === 6;
+
+          return (
+            <div
+              key={idx}
+              className="relative h-10 w-full flex items-center justify-center"
+            >
+              {/* 중앙으로 이어지는 커넥터 (반쪽) */}
+              {d && selectedStart && temp?.end && (
+                <span
+                  className="absolute inset-y-0 left-1/2 right-0 bg-main-15 -z-0"
+                  style={{
+                    borderTopRightRadius: isColEnd ? '9999px' : 0,
+                    borderBottomRightRadius: isColEnd ? '9999px' : 0,
+                  }}
+                />
+              )}
+              {d && selectedEnd && temp?.start && (
+                <span
+                  className="absolute inset-y-0 left-0 right-1/2 bg-main-15 -z-0"
+                  style={{
+                    borderTopLeftRadius: isColStart ? '9999px' : 0,
+                    borderBottomLeftRadius: isColStart ? '9999px' : 0,
+                  }}
+                />
+              )}
+
+              {/* 범위 중간(풀 폭 커넥터) */}
+              {d && inSelRange && !selectedStart && !selectedEnd && (
+                <span
+                  className="absolute inset-0 bg-main-15 -z-0"
+                  style={{
+                    borderTopLeftRadius: isColStart ? '9999px' : 0,
+                    borderBottomLeftRadius: isColStart ? '9999px' : 0,
+                    borderTopRightRadius: isColEnd ? '9999px' : 0,
+                    borderBottomRightRadius: isColEnd ? '9999px' : 0,
+                  }}
+                />
+              )}
+
+              {/* 날짜 버튼(동그라미는 시작/끝만) */}
+              <button
+                disabled={!d}
+                onClick={() => d && pick(new Date(d))}
+                className={[
+                  'relative z-10 w-10 h-10 flex items-center justify-center pt-0.5',
+                  !d ? 'opacity-0' : '',
+                  selectedStart || selectedEnd
+                    ? 'rounded-full bg-main-100 text-white'
+                    : inSelRange
+                      ? 'text-main-100' // 중간은 배경 span 위에 텍스트만
+                      : 'rounded-full bg-neutral-100 text-neutral-500 hover:bg-neutral-200',
+                ].join(' ')}
+              >
+                {d ? d.getDate() : ''}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/festival/search/_components/DateFilter.js
+++ b/src/app/festival/search/_components/DateFilter.js
@@ -89,9 +89,6 @@ export default function DateFilter({
   const isStart = (d) => d && temp?.start && fmt(d) === fmt(temp.start);
   const isEnd = (d) => d && temp?.end && fmt(d) === fmt(temp.end);
 
-  // 단일 선택 허용: start만 있어도 적용 가능
-  const canApply = !!temp?.start;
-
   return (
     <BottomSheet
       open={open}

--- a/src/app/festival/search/_components/RegionFilter.js
+++ b/src/app/festival/search/_components/RegionFilter.js
@@ -1,25 +1,40 @@
 'use client';
 
 import BottomSheet from './BottomSheet';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export default function RegionFilter({
   open,
   onClose,
   value = [],
   onChange,
-  options,
+  options = [],
 }) {
   const [temp, setTemp] = useState(value);
+  const [selectedSido, setSelectedSido] = useState('');
 
+  // options: [{ sido, sigungu }]
   const bySido = useMemo(() => {
     const map = {};
     options.forEach(({ sido, sigungu }) => {
-      if (!map[sido]) map[sido] = [];
-      map[sido].push(sigungu);
+      if (!map[sido]) map[sido] = new Set();
+      map[sido].add(sigungu);
     });
-    return map;
+    // Set -> Array, keep stable order
+    return Object.fromEntries(
+      Object.entries(map).map(([k, v]) => [k, Array.from(v)])
+    );
   }, [options]);
+
+  const sidoList = useMemo(() => Object.keys(bySido), [bySido]);
+
+  useEffect(() => {
+    if (open) {
+      setTemp(value);
+      // 초기 진입 시 첫 번째 시/도 선택
+      setSelectedSido((prev) => prev || sidoList[0] || '');
+    }
+  }, [open, value, sidoList]);
 
   const toggle = (sido, sigungu) => {
     const key = `${sido}/${sigungu}`;
@@ -28,21 +43,28 @@ export default function RegionFilter({
     );
   };
 
+  const removeChip = (key) => {
+    setTemp((prev) => prev.filter((x) => x !== key));
+  };
+
   return (
     <BottomSheet
       open={open}
       onClose={onClose}
       title="지역"
       footer={
-        <div className="flex gap-2 font-semibold pb-3">
+        <div className="flex items-center gap-2 pb-3">
           <button
-            className="flex-1 py-3 rounded-md  bg-main-15 text-main-100"
+            type="button"
+            className="px-4 py-3 rounded-md bg-main-15 text-main-100 font-semibold shrink-0"
             onClick={() => setTemp([])}
           >
             초기화
           </button>
+
           <button
-            className="flex-4 py-3 rounded-md bg-main-100 text-white"
+            type="button"
+            className="flex-1 py-3 rounded-md bg-main-100 text-white font-semibold"
             onClick={() => {
               onChange(temp);
               onClose();
@@ -53,37 +75,144 @@ export default function RegionFilter({
         </div>
       }
     >
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-2">
-          {Object.keys(bySido).map((s) => (
-            <div key={s} className="px-3 py-2 rounded border">
-              {s}
-            </div>
-          ))}
+      {/* 상단 탭 바 */}
+      <div className="grid grid-cols-2">
+        <div className="text-center py-2 font-semibold text-neutral-600 border-b border-neutral-300">
+          시/도
         </div>
-        <div className="space-y-3">
-          {Object.entries(bySido).map(([s, gus]) => (
-            <div key={s}>
-              <div className="text-xs text-neutral-500 mb-2">{s}</div>
-              <div className="flex flex-wrap gap-2">
-                {gus.map((g) => {
-                  const k = `${s}/${g}`;
-                  const active = temp.includes(k);
-                  return (
+        <div className="text-center py-2 text-neutral-600 border-b border-neutral-300">
+          시/구/군
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 min-h-[340px]">
+        {/* 좌측: 시/도 리스트 */}
+        <div className="overflow-hidden">
+          <ul className="max-h-[340px] overflow-y-auto">
+            {sidoList.map((sido) => {
+              const active = selectedSido === sido;
+              return (
+                <li key={sido}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedSido(sido)}
+                    className={[
+                      'w-full px-4 h-10 text-sm text-center',
+                      active
+                        ? 'bg-main-5 text-main-100 border-main-10'
+                        : 'bg-neutral-100 text-neutral-500 ',
+                    ].join(' ')}
+                  >
+                    {sido}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* 우측: 시/구/군 멀티선택 리스트 */}
+        <div className="flex flex-col">
+          {/* 섹션 헤더 */}
+
+          <div className="max-h-[300px] overflow-y-auto">
+            <ul>
+              {/* 전체 옵션 */}
+              {selectedSido && (
+                <li>
+                  {(() => {
+                    const k = `${selectedSido}/전체`;
+                    const active = temp.includes(k);
+                    return (
+                      <button
+                        type="button"
+                        onClick={() => toggle(selectedSido, '전체')}
+                        className="w-full px-4 h-10 flex items-center justify-between"
+                      >
+                        <span
+                          className={`text-sm ${active ? 'text-main-100' : 'text-neutral-300'}`}
+                        >
+                          전체
+                        </span>
+                        <span className="ml-3 inline-flex items-center justify-center">
+                          <i
+                            className={`mgc_check_fill  text-xl ${active ? 'text-main-100' : 'text-neutral-300'}`}
+                          />
+                        </span>
+                      </button>
+                    );
+                  })()}
+                </li>
+              )}
+
+              {(bySido[selectedSido] || []).map((g) => {
+                const k = `${selectedSido}/${g}`;
+                const active = temp.includes(k);
+                return (
+                  <li key={k}>
                     <button
-                      key={k}
-                      onClick={() => toggle(s, g)}
-                      className={`px-3 py-1 rounded-full border text-sm ${active ? 'bg-main-5 border-main-100 text-main-100' : 'border-neutral-200'}`}
+                      type="button"
+                      onClick={() => toggle(selectedSido, g)}
+                      className="w-full px-4 h-10 flex items-center justify-between border-b last:border-b-0"
                     >
-                      {g}
+                      <span
+                        className={`text-sm ${active ? 'text-main-100' : 'text-neutral-300'}`}
+                      >
+                        {g}
+                      </span>
+                      <span className="ml-3 inline-flex items-center justify-center">
+                        <i
+                          className={`mgc_check_fill  text-xl ${active ? 'text-main-100' : 'text-neutral-300'}`}
+                        />
+                      </span>
                     </button>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+      </div>
+      {/* 선택 칩 영역 */}
+      <div className="mt-3">
+        <div className="text-xs text-neutral-400 mb-2 text-right">
+          {temp.length}/10
+        </div>
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {temp.map((k) => {
+            const [s, g] = k.split('/');
+            return (
+              <span
+                key={k}
+                className="inline-flex items-center gap-1 px-2 h-6 text-sm rounded-sm bg-main-5 text-main-100 whitespace-nowrap"
+              >
+                {g === '전체' ? `${s} 전체` : g}
+                <button
+                  type="button"
+                  className="ml-1 inline-flex items-center justify-center h-3 w-3"
+                  onClick={() => removeChip(k)}
+                >
+                  <i className="mgc_close_fill text-sm text-main-40 flex justify-center items-center" />
+                </button>
+              </span>
+            );
+          })}
         </div>
       </div>
     </BottomSheet>
+  );
+}
+
+/* 칩 제거 아이콘 */
+function CloseIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      className="fill-neutral-500"
+    >
+      <path d="M18.3 5.71L12 12.01L5.7 5.71L4.29 7.12L10.59 13.41L4.29 19.71L5.7 21.12L12 14.83L18.29 21.12L19.7 19.71L13.41 13.41L19.71 7.12L18.3 5.71Z" />
+    </svg>
   );
 }

--- a/src/app/festival/search/_components/RegionFilter.js
+++ b/src/app/festival/search/_components/RegionFilter.js
@@ -1,0 +1,89 @@
+'use client';
+
+import BottomSheet from './BottomSheet';
+import { useMemo, useState } from 'react';
+
+export default function RegionFilter({
+  open,
+  onClose,
+  value = [],
+  onChange,
+  options,
+}) {
+  const [temp, setTemp] = useState(value);
+
+  const bySido = useMemo(() => {
+    const map = {};
+    options.forEach(({ sido, sigungu }) => {
+      if (!map[sido]) map[sido] = [];
+      map[sido].push(sigungu);
+    });
+    return map;
+  }, [options]);
+
+  const toggle = (sido, sigungu) => {
+    const key = `${sido}/${sigungu}`;
+    setTemp((prev) =>
+      prev.includes(key) ? prev.filter((x) => x !== key) : [...prev, key]
+    );
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="지역"
+      footer={
+        <div className="flex gap-2 font-semibold pb-3">
+          <button
+            className="flex-1 py-3 rounded-md  bg-main-15 text-main-100"
+            onClick={() => setTemp([])}
+          >
+            초기화
+          </button>
+          <button
+            className="flex-4 py-3 rounded-md bg-main-100 text-white"
+            onClick={() => {
+              onChange(temp);
+              onClose();
+            }}
+          >
+            총 {temp.length}개 결과 보기
+          </button>
+        </div>
+      }
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          {Object.keys(bySido).map((s) => (
+            <div key={s} className="px-3 py-2 rounded border">
+              {s}
+            </div>
+          ))}
+        </div>
+        <div className="space-y-3">
+          {Object.entries(bySido).map(([s, gus]) => (
+            <div key={s}>
+              <div className="text-xs text-neutral-500 mb-2">{s}</div>
+              <div className="flex flex-wrap gap-2">
+                {gus.map((g) => {
+                  const k = `${s}/${g}`;
+                  const active = temp.includes(k);
+                  return (
+                    <button
+                      key={k}
+                      onClick={() => toggle(s, g)}
+                      className={`px-3 py-1 rounded-full border text-sm ${active ? 'bg-main-5 border-main-100 text-main-100' : 'border-neutral-200'}`}
+                    >
+                      {g}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/festival/search/_components/SortFilter.js
+++ b/src/app/festival/search/_components/SortFilter.js
@@ -1,0 +1,30 @@
+'use client';
+
+import BottomSheet from './BottomSheet';
+
+const OPTIONS = ['추천순', '최신순', '좋아요순'];
+
+export default function SortFilter({ open, onClose, value, onChange }) {
+  return (
+    <BottomSheet open={open} onClose={onClose} title="정렬">
+      <div className="space-y-2 pb-6">
+        {OPTIONS.map((o) => {
+          const active = value === o;
+          return (
+            <button
+              key={o}
+              onClick={() => {
+                onChange(o);
+                onClose();
+              }}
+              className={`flex justify-between items-center w-full text-left px-4 py-3 rounded-lg ${active ? 'bg-main-5 text-main-100' : 'bg-neutral-100 text-neutral-600'}`}
+            >
+              {o}
+              {active && <i className="mgc_check_fill text-main-100 text-xl" />}
+            </button>
+          );
+        })}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/festival/search/page.js
+++ b/src/app/festival/search/page.js
@@ -57,10 +57,17 @@ export default function SearchPage() {
     });
   };
 
-  return (
-    <div className="max-w-[390px] w-full h-screen bg-background mx-auto pt-4">
-      {/* 검색창 */}
+  const goToResult = (keyword) => {
+    const encoded = encodeURIComponent(keyword);
+    const base = `/festival/search/result?query=${encoded}`;
+    const path = isSelectMode ? `${base}&mode=select` : base;
+    saveRecentSearch(keyword);
+    router.push(path);
+  };
 
+  return (
+    <div className="max-w-[390px] w-full h-screen bg-background mx-auto pt-[50px]">
+      {/* 검색창 */}
       <div className="px-4">
         <SearchInputBar
           value={input}
@@ -84,19 +91,13 @@ export default function SearchPage() {
         <h3 className="text-sm mb-3 font-semibold">최근 검색어</h3>
         <div className="flex gap-2 flex-wrap">
           {recentSearches.map((tag) => {
-            const encoded = encodeURIComponent(tag);
-            const base = `/festival/search/result?query=${encoded}`;
-            const path = isSelectMode ? `${base}&mode=select` : base;
             return (
               <button
                 key={tag}
-                onClick={() => {
-                  saveRecentSearch(tag);
-                  router.push(path);
-                }}
-                className="bg-transparent text-xs px-2 py-1 rounded-full border border-neutral-200 text-neutral-900 flex items-center gap-1"
+                onClick={() => goToResult(tag)}
+                className="bg-transparent text-xs px-2 py-1 rounded-full border border-neutral-200 text-neutral-900 flex items-center justify-center gap-1"
               >
-                <span>{tag}</span>
+                <span className="pt-0.5">{tag}</span>
                 <span
                   onClick={(e) => {
                     e.stopPropagation();
@@ -104,7 +105,7 @@ export default function SearchPage() {
                   }}
                   className="text-[10px] text-neutral-300 cursor-pointer"
                 >
-                  ✕
+                  <i className="mgc_close_line flex justify-center items-center text-xs" />
                 </span>
               </button>
             );
@@ -127,11 +128,12 @@ export default function SearchPage() {
           {/* 왼쪽 컬럼 */}
           <div className="flex-1 space-y-2 text-sm text-gray-800">
             {trending.slice(0, 4).map((item, idx) => (
-              <div
+              <button
                 key={item.keyword}
-                className="flex items-center justify-between pr-4 p-0.5"
+                onClick={() => goToResult(item.keyword)}
+                className="w-full flex items-center justify-between pr-4 p-0.5"
               >
-                <span>
+                <span className="flex items-center">
                   <span className="mr-5 text-neutral-500 text-xs">
                     {idx + 1}
                   </span>
@@ -148,18 +150,19 @@ export default function SearchPage() {
                     <span className="text-neutral-400 px-2.5 py-1">–</span>
                   )}
                 </span>
-              </div>
+              </button>
             ))}
           </div>
 
           {/* 오른쪽 컬럼 */}
           <div className="flex-1 space-y-2 text-sm text-gray-800">
             {trending.slice(4).map((item, idx) => (
-              <div
+              <button
                 key={item.keyword}
-                className="flex items-center justify-between pr-4 p-0.5"
+                onClick={() => goToResult(item.keyword)}
+                className="w-full flex items-center justify-between pr-4 p-0.5"
               >
-                <span>
+                <span className="flex items-center">
                   <span className="mr-5 text-neutral-500 text-xs">
                     {idx + 5}
                   </span>
@@ -176,7 +179,7 @@ export default function SearchPage() {
                     <span className="text-neutral-400 px-2.5 py-1">–</span>
                   )}
                 </span>
-              </div>
+              </button>
             ))}
           </div>
         </div>

--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -107,14 +107,6 @@ export default function FestivalSearchResultPage() {
     return res.sort(sorter);
   }, [searchQuery, regions, categories, period, sort]);
 
-  const clearAll = () => {
-    setSort('');
-    setRegions([]);
-    setCategories([]);
-    setPeriod({ start: null, end: null });
-    setSheet(null);
-  };
-
   // 옵션 예시
   const regionOptions = [
     { sido: '서울', sigungu: '강남구' },
@@ -142,10 +134,6 @@ export default function FestivalSearchResultPage() {
     : '분야';
   const fmt = (d) =>
     d ? `${String(d.getMonth() + 1)}/${String(d.getDate())}` : '';
-  const dateLabel =
-    period.start && period.end
-      ? `${fmt(period.start)}~${fmt(period.end)}`
-      : '기간';
   const sortLabel = sort || '정렬';
 
   // 공통 버튼 스타일

--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -117,8 +117,10 @@ export default function FestivalSearchResultPage() {
   const categoryOptions = [
     '관광축제',
     '예술축제',
+    '특산물축제',
     '전통축제',
     '자연축제',
+    '기타축제',
     '공연',
     '행사',
   ];

--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -1,36 +1,69 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { mockFestivals } from '../../mockData';
 import SearchInputBar from '@/app/festival/_components/SearchInputBar';
-import { FiFilter } from 'react-icons/fi';
-import { IoIosArrowDown } from 'react-icons/io';
+import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
 import FestivalListItem from '@/app/festival/_components/FestivalListItem';
+import SortFilter from '@/app/festival/search/_components/SortFilter';
+import RegionFilter from '@/app/festival/search/_components/RegionFilter';
+import CategoryFilter from '@/app/festival/search/_components/CategoryFilter';
+import DateFilter from '@/app/festival/search/_components/DateFilter';
 
 export default function FestivalSearchResultPage() {
   const router = useRouter();
-  const pathname = usePathname();
   const [mode, setMode] = useState('default');
+
+  //검색 맟 압력
+  const [searchQuery, setSearchQuery] = useState('');
+  const [input, setInput] = useState('');
+
+  // 좋아요 상태
+  const [likedIds, setLikedIds] = useState([]);
+
+  // 필터 상태
+  const [sort, setSort] = useState('');
+  const [regions, setRegions] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [period, setPeriod] = useState({ start: null, end: null });
+
+  // 필터 시트 열림 상태
+  const [sheet, setSheet] = useState(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const modeParam = params.get('mode');
-    if (modeParam === 'select') {
-      setMode('select');
-    }
-  }, []);
+    if (modeParam === 'select') setMode('select');
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [input, setInput] = useState('');
-  const [likedIds, setLikedIds] = useState([]);
+    const q = params.get('query') || '';
+    setSearchQuery(q);
+    setInput(q);
+
+    const s = params.get('sort') || '';
+    setSort(s);
+
+    const r = (params.get('regions') || '').split(',').filter(Boolean);
+    setRegions(r);
+
+    const c = (params.get('categories') || '').split(',').filter(Boolean);
+    setCategories(c);
+
+    const start = params.get('start');
+    const end = params.get('end');
+    setPeriod({
+      start: start ? new Date(start) : null,
+      end: end ? new Date(end) : null,
+    });
+  }, []);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const query = params.get('query') || '';
-    setSearchQuery(query);
-    setInput(query);
-  }, []);
+    if (sheet) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [sheet]);
 
   const handleEnter = (text) => {
     setSearchQuery(text);
@@ -43,12 +76,88 @@ export default function FestivalSearchResultPage() {
     );
   };
 
-  const filteredFestivals = mockFestivals.filter((f) =>
-    f.title.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  // 정렬
+  const sorter = (a, b) => {
+    if (sort === '최신순') return new Date(b.createdAt) - new Date(a.createdAt);
+    if (sort === '좋아요순') return (b.likes ?? 0) - (a.likes ?? 0);
+    return (b.score ?? 0) - (a.score ?? 0); // 추천순
+  };
+  // 목록 필터링
+  const filteredFestivals = useMemo(() => {
+    const text = (searchQuery || '').toLowerCase();
+    let res = mockFestivals.filter((f) => f.title.toLowerCase().includes(text));
+
+    if (regions.length) {
+      res = res.filter((f) =>
+        regions.includes(`${f.regionSido}/${f.regionSigungu}`)
+      );
+    }
+    if (categories.length) {
+      res = res.filter((f) => categories.includes(f.category));
+    }
+    if (period.start || period.end) {
+      res = res.filter((f) => {
+        const s = new Date(f.startDate);
+        const e = new Date(f.endDate);
+        const okStart = period.start ? e >= period.start : true;
+        const okEnd = period.end ? s <= period.end : true;
+        return okStart && okEnd;
+      });
+    }
+    return res.sort(sorter);
+  }, [searchQuery, regions, categories, period, sort]);
+
+  const clearAll = () => {
+    setSort('');
+    setRegions([]);
+    setCategories([]);
+    setPeriod({ start: null, end: null });
+    setSheet(null);
+  };
+
+  // 옵션 예시
+  const regionOptions = [
+    { sido: '서울', sigungu: '강남구' },
+    { sido: '서울', sigungu: '광진구' },
+    { sido: '서울', sigungu: '강북구' },
+    { sido: '부산', sigungu: '해운대구' },
+  ];
+  const categoryOptions = [
+    '관광축제',
+    '예술축제',
+    '전통축제',
+    '자연축제',
+    '공연',
+    '행사',
+  ];
+
+  // 라벨/요약
+  const firstSigungu = (v) => (v[0] ? v[0].split('/')[1] || v[0] : '');
+  const countLabel = (v) => (v.length > 1 ? ` 외 ${v.length - 1}` : '');
+  const regionLabel = regions.length
+    ? `${firstSigungu(regions)}${countLabel(regions)}`
+    : '지역';
+  const categoryLabel = categories.length
+    ? `${categories[0]}${countLabel(categories)}`
+    : '분야';
+  const fmt = (d) =>
+    d ? `${String(d.getMonth() + 1)}/${String(d.getDate())}` : '';
+  const dateLabel =
+    period.start && period.end
+      ? `${fmt(period.start)}~${fmt(period.end)}`
+      : '기간';
+  const sortLabel = sort || '정렬';
+
+  // 공통 버튼 스타일
+  const chip = (active) =>
+    `px-2 py-0.5 rounded-full border text-xs inline-flex items-center gap-1 whitespace-nowrap shrink-0 ${
+      active
+        ? 'bg-main-5 border-main-100 text-main-100'
+        : 'border-neutral-200 text-neutral-900'
+    }`;
 
   return (
-    <div className="max-w-[390px] w-full h-screen mx-auto px-4 pt-4 pb-28">
+    <div className="max-w-[390px] w-screen h-screen mx-auto px-4 pt-4 pb-28">
       <SearchInputBar
         value={input}
         onChange={(e) => setInput(e.target.value)}
@@ -58,26 +167,49 @@ export default function FestivalSearchResultPage() {
       />
 
       {mode !== 'select' && (
-        <>
-          <div className="flex gap-2 items-center mt-3 mb-3">
-            {['정렬기준', '지역', '분야', '기간'].map((tag) => (
-              <button
-                key={tag}
-                className="bg-transparent text-xs px-2 py-1 rounded-full border border-neutral-200  text-neutral-900 flex items-center gap-1"
-              >
-                <span>{tag}</span>
-                <IoIosArrowDown />
-              </button>
-            ))}
-            <button className="ml-auto p-1">
-              <FiFilter className="text-neutral-500 w-4 h-4" />
+        <div>
+          {/* 상단 요약 필터 바: 선택값이 버튼 안을 채우게 */}
+          <div className="flex items-center gap-2 overflow-x-auto flex-nowrap scrollbar-hide mt-3 mb-2">
+            <button
+              className={chip(sort !== '')}
+              onClick={() => setSheet('sort')}
+            >
+              <span className="mt-0.5 ml-0.5">{sortLabel}</span>
+              {sheet === 'sort' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+            </button>
+            <button
+              className={chip(!!regions.length)}
+              onClick={() => setSheet('region')}
+            >
+              <span className="mt-0.5 ml-0.5">{regionLabel}</span>
+              {sheet === 'region' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+            </button>
+            <button
+              className={chip(!!categories.length)}
+              onClick={() => setSheet('category')}
+            >
+              <span className="mt-0.5 ml-0.5">{categoryLabel}</span>
+              {sheet === 'category' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+            </button>
+            <button
+              className={chip(!!period.start)}
+              onClick={() => setSheet('date')}
+            >
+              <span className="mt-0.5 ml-0.5">
+                {period.start
+                  ? period.end
+                    ? `${fmt(period.start)}~${fmt(period.end)}`
+                    : `${fmt(period.start)}`
+                  : '기간'}
+              </span>
+              {sheet === 'date' ? <IoIosArrowUp /> : <IoIosArrowDown />}
             </button>
           </div>
 
-          <div className="text-xs text-neutral-600">
+          <div className="text-xs text-neutral-600 pt-4">
             검색결과 ({filteredFestivals.length})
           </div>
-        </>
+        </div>
       )}
 
       <div className="space-y-4 h-full mt-3">
@@ -111,7 +243,6 @@ export default function FestivalSearchResultPage() {
               }
             >
               <FestivalListItem
-                key={festival.id}
                 festival={festival}
                 liked={likedIds.includes(festival.id)}
                 onLike={() => toggleLike(festival.id)}
@@ -127,6 +258,47 @@ export default function FestivalSearchResultPage() {
             </div>
           ))
         )}
+      </div>
+
+      {sheet && (
+        <button
+          className="fixed inset-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] bg-black/25 z-99"
+          onClick={() => setSheet(null)}
+          aria-label="필터 닫기"
+        />
+      )}
+      <div
+        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] z-100 transition-transform duration-300 ease-in-out ${
+          sheet ? 'translate-y-0' : 'translate-y-[100vh]'
+        }`}
+      >
+        <SortFilter
+          open={sheet === 'sort'}
+          onClose={() => setSheet(null)}
+          value={sort}
+          onChange={setSort}
+        />
+        <RegionFilter
+          open={sheet === 'region'}
+          onClose={() => setSheet(null)}
+          value={regions}
+          onChange={setRegions}
+          options={regionOptions}
+        />
+        <CategoryFilter
+          open={sheet === 'category'}
+          onClose={() => setSheet(null)}
+          value={categories}
+          onChange={setCategories}
+          options={categoryOptions}
+        />
+        <DateFilter
+          open={sheet === 'date'}
+          onClose={() => setSheet(null)}
+          value={period}
+          onChange={setPeriod}
+          // resultCount={filteredFestivals.length} // 쓰면 "총 N개 결과 보기" 표시 가능
+        />
       </div>
     </div>
   );

--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -216,7 +216,7 @@ export default function FestivalSearchResultPage() {
         </div>
         <div className="space-y-4">
           {filteredFestivals.length === 0 ? (
-            <div className="flex flex-col h-full items-center justify-center gap-3">
+            <div className="flex flex-col flex-1 items-center justify-center gap-3 min-h-[calc(100vh-200px)]">
               <i className="mgc_sweats_fill text-6xl text-main-100" />
               <p className="text-center text-lg font-semibold">
                 앗, 관련 축제가 없어요!

--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -145,120 +145,133 @@ export default function FestivalSearchResultPage() {
     }`;
 
   return (
-    <div className="max-w-[390px] w-screen h-screen mx-auto px-4 pt-4 pb-28">
-      <SearchInputBar
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onEnter={handleEnter}
-        onClear={() => router.push('/festival/search')}
-        withBack
-      />
+    <div className="max-w-[390px] mx-auto h-screen w-screen flex flex-col bg-background">
+      {/* 고정 헤더 */}
+      <header className="sticky top-0 z-[10] bg-background">
+        <div className="pt-[50px] px-4 pb-3">
+          <SearchInputBar
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onEnter={handleEnter}
+            onClear={() => router.push('/festival/search')}
+            withBack
+          />
 
-      {mode !== 'select' && (
-        <div>
-          {/* 상단 요약 필터 바: 선택값이 버튼 안을 채우게 */}
-          <div className="flex items-center gap-2 overflow-x-auto flex-nowrap scrollbar-hide mt-3 mb-2">
-            <button
-              className={chip(sort !== '')}
-              onClick={() => setSheet('sort')}
-            >
-              <span className="mt-0.5 ml-0.5">{sortLabel}</span>
-              {sheet === 'sort' ? <IoIosArrowUp /> : <IoIosArrowDown />}
-            </button>
-            <button
-              className={chip(!!regions.length)}
-              onClick={() => setSheet('region')}
-            >
-              <span className="mt-0.5 ml-0.5">{regionLabel}</span>
-              {sheet === 'region' ? <IoIosArrowUp /> : <IoIosArrowDown />}
-            </button>
-            <button
-              className={chip(!!categories.length)}
-              onClick={() => setSheet('category')}
-            >
-              <span className="mt-0.5 ml-0.5">{categoryLabel}</span>
-              {sheet === 'category' ? <IoIosArrowUp /> : <IoIosArrowDown />}
-            </button>
-            <button
-              className={chip(!!period.start)}
-              onClick={() => setSheet('date')}
-            >
-              <span className="mt-0.5 ml-0.5">
-                {period.start
-                  ? period.end
-                    ? `${fmt(period.start)}~${fmt(period.end)}`
-                    : `${fmt(period.start)}`
-                  : '기간'}
-              </span>
-              {sheet === 'date' ? <IoIosArrowUp /> : <IoIosArrowDown />}
-            </button>
-          </div>
-
-          <div className="text-xs text-neutral-600 pt-4">
-            검색결과 ({filteredFestivals.length})
-          </div>
+          {mode !== 'select' && (
+            <>
+              {/* 칩 바: 가로 스크롤 */}
+              <div className="flex items-center gap-2 overflow-x-auto flex-nowrap scrollbar-hide mt-3">
+                <button
+                  className={chip(sort !== '')}
+                  onClick={() => setSheet(sheet === 'sort' ? null : 'sort')}
+                >
+                  <span className="mt-0.5 ml-0.5 whitespace-nowrap">
+                    {sortLabel}
+                  </span>
+                  {sheet === 'sort' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                </button>
+                <button
+                  className={chip(!!regions.length)}
+                  onClick={() => setSheet(sheet === 'region' ? null : 'region')}
+                >
+                  <span className="mt-0.5 ml-0.5 whitespace-nowrap">
+                    {regionLabel}
+                  </span>
+                  {sheet === 'region' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                </button>
+                <button
+                  className={chip(!!categories.length)}
+                  onClick={() =>
+                    setSheet(sheet === 'category' ? null : 'category')
+                  }
+                >
+                  <span className="mt-0.5 ml-0.5 whitespace-nowrap">
+                    {categoryLabel}
+                  </span>
+                  {sheet === 'category' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                </button>
+                <button
+                  className={chip(!!period.start)}
+                  onClick={() => setSheet(sheet === 'date' ? null : 'date')}
+                >
+                  <span className="mt-0.5 ml-0.5 whitespace-nowrap">
+                    {period.start
+                      ? period.end
+                        ? `${fmt(period.start)}~${fmt(period.end)}`
+                        : `${fmt(period.start)}`
+                      : '기간'}
+                  </span>
+                  {sheet === 'date' ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                </button>
+              </div>
+            </>
+          )}
         </div>
-      )}
+      </header>
 
-      <div className="space-y-4 h-full mt-3">
-        {filteredFestivals.length === 0 ? (
-          <div
-            className="flex flex-col h-full items-center justify-center gap-3"
-            style={{ height: 'calc(100% - 80px)' }}
-          >
-            <i className="mgc_sweats_fill text-6xl text-main-100" />
-            <p className="text-center text-lg font-semibold">
-              앗, 관련 축제가 없어요!
-            </p>
-            <p className="text-center text-sm text-neutral-500">
-              다른 키워드로 다시 검색해 주세요 😢
-            </p>
-            <button
-              onClick={() => router.push('/festival')}
-              className="mt-4 px-6 py-2 rounded-md bg-main-5 text-main-100 text-xl font-medium "
-            >
-              축제 메인으로 돌아가기
-            </button>
-          </div>
-        ) : (
-          filteredFestivals.map((festival) => (
-            <div
-              key={festival.id}
-              onClick={() =>
-                mode === 'select'
-                  ? null
-                  : router.push(`/festival/${festival.id}`)
-              }
-            >
-              <FestivalListItem
-                festival={festival}
-                liked={likedIds.includes(festival.id)}
-                onLike={() => toggleLike(festival.id)}
-                mode={mode}
-                onSelect={() => {
-                  sessionStorage.setItem(
-                    'selectedFestival',
-                    JSON.stringify(festival)
-                  );
-                  router.push('/diary/write');
-                }}
-              />
+      {/* 스크롤 영역 */}
+      <main className="flex-1 overflow-y-auto p-4 scrollbar-hide">
+        <div className="text-xs text-neutral-600 mb-3">
+          검색결과 ({filteredFestivals.length})
+        </div>
+        <div className="space-y-4">
+          {filteredFestivals.length === 0 ? (
+            <div className="flex flex-col h-full items-center justify-center gap-3">
+              <i className="mgc_sweats_fill text-6xl text-main-100" />
+              <p className="text-center text-lg font-semibold">
+                앗, 관련 축제가 없어요!
+              </p>
+              <p className="text-center text-sm text-neutral-500">
+                다른 키워드로 다시 검색해 주세요 😢
+              </p>
+              <button
+                onClick={() => router.push('/festival')}
+                className="mt-4 px-6 py-2 rounded-md bg-main-5 text-main-100 text-xl font-medium "
+              >
+                축제 메인으로 돌아가기
+              </button>
             </div>
-          ))
-        )}
-      </div>
+          ) : (
+            filteredFestivals.map((festival) => (
+              <div
+                key={festival.id}
+                onClick={() =>
+                  mode === 'select'
+                    ? null
+                    : router.push(`/festival/${festival.id}`)
+                }
+              >
+                <FestivalListItem
+                  festival={festival}
+                  liked={likedIds.includes(festival.id)}
+                  onLike={() => toggleLike(festival.id)}
+                  mode={mode}
+                  onSelect={() => {
+                    sessionStorage.setItem(
+                      'selectedFestival',
+                      JSON.stringify(festival)
+                    );
+                    router.push('/diary/write');
+                  }}
+                />
+              </div>
+            ))
+          )}
+        </div>
+      </main>
 
+      {/* 오버레이 & 시트 (z-index 유효 클래스!) */}
       {sheet && (
         <button
-          className="fixed inset-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] bg-black/25 z-99"
+          className="fixed inset-0 bg-black/25 z-[99]"
           onClick={() => setSheet(null)}
           aria-label="필터 닫기"
         />
       )}
       <div
-        className={`fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[390px] z-100 transition-transform duration-300 ease-in-out ${
-          sheet ? 'translate-y-0' : 'translate-y-[100vh]'
-        }`}
+        className={`fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] z-[100]
+        bg-background rounded-t-xl px-4 py-8 transition-transform duration-300 ease-in-out
+        ${sheet ? 'translate-y-0' : 'translate-y-[100vh]'}`}
       >
         <SortFilter
           open={sheet === 'sort'}
@@ -285,7 +298,6 @@ export default function FestivalSearchResultPage() {
           onClose={() => setSheet(null)}
           value={period}
           onChange={setPeriod}
-          // resultCount={filteredFestivals.length} // 쓰면 "총 N개 결과 보기" 표시 가능
         />
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,7 @@
   --font-sans: Pretendard, system-ui, sans-serif;
   --color-main-100: #35C284;
   --color-main-40: #A8E4CA;
+  --color-main-15: #E1F6ED;
   --color-main-5: #F4FBF8;
   --color-sub-100: #FACC15;
   --color-sub-15: #FDF4D1;
@@ -52,38 +53,4 @@
 }
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
-}
-
-/*캘린더 커스터마이징*/
-.DayPicker-Day {
-  padding: 6px !important;
-}
-
-.DayPicker-Day:hover {
-  background-color: transparent !important;
-}
-
-.DayPicker-Weekday {
-  color: #171717 !important;
-  font-weight: 500;
-  font-size: 13px;
-}
-
-.DayPicker-NavButton {
-  color: #737373 !important; /* neutral-500 */
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.DayPicker-NavButton--prev,
-.DayPicker-NavButton--next{
-  font-size: 13px;
-}
-
-.DayPicker-Day--selected {
-  background-color: transparent !important; /* main-100 */
-  color: #ffffff !important;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -14,7 +14,7 @@ export default function RootLayout({ children }) {
           {/* 고정된 앱 화면 높이에서 */}
           <main
             id="main"
-            className="flex-1 bg-background overflow-y-auto scrollbar-hide"
+            className="flex-1 bg-background overflow-y-auto scrollbar-hide w-max"
           >
             <div className="h-full pb-18">{children}</div>
           </main>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,6 @@
 import './globals.css';
 import BottomNavBar from './_components/BottomNavBar';
+import AuthBootstrap from '@/app/_providers/AuthBootstrap';
 
 export const metadata = {
   title: 'Dori Room',
@@ -16,7 +17,9 @@ export default function RootLayout({ children }) {
             id="main"
             className="flex-1 bg-background overflow-y-auto scrollbar-hide w-max"
           >
-            <div className="h-full pb-18">{children}</div>
+            <div className="h-full pb-18">
+              <AuthBootstrap>{children}</AuthBootstrap>
+            </div>
           </main>
           <BottomNavBar />
         </div>

--- a/src/hooks/auth/useSignIn.js
+++ b/src/hooks/auth/useSignIn.js
@@ -1,0 +1,65 @@
+// hooks/auth/useSignIn.js
+'use client';
+
+import { useCallback, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+function saveTokens({ accessToken, refreshToken }, remember) {
+  try {
+    const primary = remember ? localStorage : sessionStorage;
+    const secondary = remember ? sessionStorage : localStorage;
+    secondary.removeItem('access_token');
+    secondary.removeItem('refresh_token');
+    primary.setItem('access_token', accessToken);
+    primary.setItem('refresh_token', refreshToken);
+  } catch (_) {}
+}
+
+export default function useSignIn() {
+  const [signingIn, setSigningIn] = useState(false);
+  const [error, setError] = useState(null);
+
+  const signIn = useCallback(async ({ remember = true } = {}) => {
+    setSigningIn(true);
+    setError(null);
+    let res;
+    try {
+      res = await axiosInstance.post(
+        'auth/login',
+        { username: 'user1234', password: 'Passw0rd!' },
+        { headers: { 'Content-Type': 'application/json' }, _skipAuthRefresh: true }
+      );
+    } catch (e) {
+      setError(e);
+      return Promise.reject(e); // throw 대신 반환
+    } finally {
+      setSigningIn(false);
+    }
+
+    const content = res?.data?.content || {};
+    const accessToken = content.accessToken;
+    const refreshToken = content.refreshToken;
+
+    if (!accessToken || !refreshToken) {
+      const err = new Error('Invalid login response');
+      setError(err);
+      return Promise.reject(err); // try 바깥 검증, throw 사용 안 함
+    }
+
+    saveTokens({ accessToken, refreshToken }, remember);
+    axiosInstance.defaults.headers.Authorization = `Bearer ${accessToken}`;
+    return { accessToken, refreshToken };
+  }, []);
+
+  const signOut = useCallback(() => {
+    try {
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('refresh_token');
+      sessionStorage.removeItem('access_token');
+      sessionStorage.removeItem('refresh_token');
+      delete axiosInstance.defaults.headers.Authorization;
+    } catch (_) {}
+  }, []);
+
+  return { signIn, signOut, signingIn, error };
+}

--- a/src/hooks/auth/useSignIn.js
+++ b/src/hooks/auth/useSignIn.js
@@ -1,4 +1,3 @@
-// hooks/auth/useSignIn.js
 'use client';
 
 import { useCallback, useState } from 'react';
@@ -27,7 +26,10 @@ export default function useSignIn() {
       res = await axiosInstance.post(
         'auth/login',
         { username: 'user1234', password: 'Passw0rd!' },
-        { headers: { 'Content-Type': 'application/json' }, _skipAuthRefresh: true }
+        {
+          headers: { 'Content-Type': 'application/json' },
+          _skipAuthRefresh: true,
+        }
       );
     } catch (e) {
       setError(e);

--- a/src/hooks/festival/useFestivalDetail.js
+++ b/src/hooks/festival/useFestivalDetail.js
@@ -33,7 +33,6 @@ function normalizeFestival(api) {
   if (!api) return null;
   const startDate = formatDisplayDate(api.startDate);
   const endDate = formatDisplayDate(api.endDate);
-  const price = normalizePrice(api.useTimeFestival);
 
   // sponsor1, sponsor2 합치기
   const hostParts = [];
@@ -52,7 +51,7 @@ function normalizeFestival(api) {
     endTime: '',
     location: api.addr1 || '',
     host, // 합친 값 저장
-    price,
+    price: api.useTimeFestival ||'',
     likes: typeof api.favoriteCount === 'number' ? api.favoriteCount : 0,
     details: [],
     reviews: [],

--- a/src/hooks/festival/useFestivalDetail.js
+++ b/src/hooks/festival/useFestivalDetail.js
@@ -3,12 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 
-// 날짜 포맷 유틸(입력 예: "2025.08.07" → 그대로 표시용 리턴)
-function formatDisplayDate(yyyyDotMmDotDd) {
-  return yyyyDotMmDotDd || '';
-}
-
-// 상태 계산: 진행중/예정/종료
+// 진행중/예정/종료 상태
 function calcStatus(start, end) {
   if (!start || !end) return '';
   const today = new Date();
@@ -19,13 +14,11 @@ function calcStatus(start, end) {
   return '진행 중';
 }
 
-// API → UI 전용 모델로 정규화
 function normalizeFestival(api) {
   if (!api) return null;
-  const startDate = formatDisplayDate(api.startDate);
-  const endDate = formatDisplayDate(api.endDate);
+  const startDate = api.startDate;
+  const endDate = api.endDate;
 
-  // sponsor1, sponsor2 합치기
   const hostParts = [];
   if (api.sponsor1) hostParts.push(api.sponsor1);
   if (api.sponsor2) hostParts.push(api.sponsor2);
@@ -41,7 +34,7 @@ function normalizeFestival(api) {
     startTime: '',
     endTime: '',
     location: api.addr1 || '',
-    host, // 합친 값 저장
+    host,
     price: api.useTimeFestival || '',
     likes: typeof api.favoriteCount === 'number' ? api.favoriteCount : 0,
     details: [],
@@ -65,7 +58,7 @@ export default function useFestivalDetail(festivalId) {
     async function fetchDetail() {
       try {
         setLoading(true);
-        const res = await axiosInstance.get(`/event/detail/${festivalId}`);
+        const res = await axiosInstance.get(`event/detail/${festivalId}`);
         const apiContent = res.data?.content || null;
         if (!mounted) return;
         setFestival(normalizeFestival(apiContent));

--- a/src/hooks/festival/useFestivalDetail.js
+++ b/src/hooks/festival/useFestivalDetail.js
@@ -1,4 +1,3 @@
-// /app/hooks/useFestivalDetail.js
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
@@ -18,14 +17,6 @@ function calcStatus(start, end) {
   if (today < s) return '진행 예정';
   if (today > e) return '행사 종료';
   return '진행 중';
-}
-
-// 가격/요금 파싱(문구가 오면 그대로, 숫자면 숫자 처리)
-function normalizePrice(useTimeFestival) {
-  if (!useTimeFestival) return '';
-  const num = parseInt(useTimeFestival.replace(/[^\d]/g, ''), 10);
-  if (!isNaN(num)) return num; // 숫자면 원 단위 숫자 반환
-  return useTimeFestival; // 문구면 그대로
 }
 
 // API → UI 전용 모델로 정규화
@@ -51,7 +42,7 @@ function normalizeFestival(api) {
     endTime: '',
     location: api.addr1 || '',
     host, // 합친 값 저장
-    price: api.useTimeFestival ||'',
+    price: api.useTimeFestival || '',
     likes: typeof api.favoriteCount === 'number' ? api.favoriteCount : 0,
     details: [],
     reviews: [],
@@ -82,8 +73,7 @@ export default function useFestivalDetail(festivalId) {
         if (!mounted) return;
         setError(err);
       } finally {
-        if (!mounted) return;
-        setLoading(false);
+        if (mounted) setLoading(false);
       }
     }
 

--- a/src/hooks/festival/useFestivalDetail.js
+++ b/src/hooks/festival/useFestivalDetail.js
@@ -1,0 +1,101 @@
+// /app/hooks/useFestivalDetail.js
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+// 날짜 포맷 유틸(입력 예: "2025.08.07" → 그대로 표시용 리턴)
+function formatDisplayDate(yyyyDotMmDotDd) {
+  return yyyyDotMmDotDd || '';
+}
+
+// 상태 계산: 진행중/예정/종료
+function calcStatus(start, end) {
+  if (!start || !end) return '';
+  const today = new Date();
+  const s = new Date(start.replace(/\./g, '-'));
+  const e = new Date(end.replace(/\./g, '-'));
+  if (today < s) return '진행 예정';
+  if (today > e) return '행사 종료';
+  return '진행 중';
+}
+
+// 가격/요금 파싱(문구가 오면 그대로, 숫자면 숫자 처리)
+function normalizePrice(useTimeFestival) {
+  if (!useTimeFestival) return '';
+  const num = parseInt(useTimeFestival.replace(/[^\d]/g, ''), 10);
+  if (!isNaN(num)) return num; // 숫자면 원 단위 숫자 반환
+  return useTimeFestival; // 문구면 그대로
+}
+
+// API → UI 전용 모델로 정규화
+function normalizeFestival(api) {
+  if (!api) return null;
+  const startDate = formatDisplayDate(api.startDate);
+  const endDate = formatDisplayDate(api.endDate);
+  const price = normalizePrice(api.useTimeFestival);
+
+  // sponsor1, sponsor2 합치기
+  const hostParts = [];
+  if (api.sponsor1) hostParts.push(api.sponsor1);
+  if (api.sponsor2) hostParts.push(api.sponsor2);
+  const host = hostParts.join(', ');
+
+  return {
+    id: api.eventId,
+    title: api.title,
+    thumbnail: api.firstImage || '',
+    status: calcStatus(api.startDate, api.endDate),
+    startDate,
+    endDate,
+    startTime: '',
+    endTime: '',
+    location: api.addr1 || '',
+    host, // 합친 값 저장
+    price,
+    likes: typeof api.favoriteCount === 'number' ? api.favoriteCount : 0,
+    details: [],
+    reviews: [],
+    visitedFriend: 0,
+    eventIntro: api.eventIntro || '',
+    eventContent: api.eventContent || '',
+    _raw: api,
+  };
+}
+
+export default function useFestivalDetail(festivalId) {
+  const [festival, setFestival] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!festivalId) return;
+    let mounted = true;
+
+    async function fetchDetail() {
+      try {
+        setLoading(true);
+        const res = await axiosInstance.get(`/event/detail/${festivalId}`);
+        const apiContent = res.data?.content || null;
+        if (!mounted) return;
+        setFestival(normalizeFestival(apiContent));
+      } catch (err) {
+        if (!mounted) return;
+        setError(err);
+      } finally {
+        if (!mounted) return;
+        setLoading(false);
+      }
+    }
+
+    fetchDetail();
+    return () => {
+      mounted = false;
+    };
+  }, [festivalId]);
+
+  // 필요 시 메모
+  const data = useMemo(() => festival, [festival]);
+
+  return { festival: data, loading, error };
+}

--- a/src/hooks/festival/useMainFestivals.js
+++ b/src/hooks/festival/useMainFestivals.js
@@ -12,9 +12,9 @@ function normalizeFestival(item) {
     startDate: item.startDate,
     endDate: item.endDate,
 
-    areaName: item.areaName,
+    region: item.areaName,
     areaCode: item.areaCode,
-    categoryName: item.categoryName,
+    category: item.categoryName,
 
     likes: typeof item.favoriteCount === 'number' ? item.favoriteCount : 0,
     thumbnail: item.firstImage || item.secondImage || '',

--- a/src/hooks/festival/useMainFestivals.js
+++ b/src/hooks/festival/useMainFestivals.js
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+// API 응답 → 카드에서 쓰기 좋은 형태로 정규화
+function normalizeFestival(item) {
+  return {
+    id: item.eventId, // 기존 mock의 id 대체
+    eventId: item.eventId,
+    contentId: item.contentId,
+
+    title: item.title,
+    location: item.addr1 ?? '', // mock의 location 대응
+    startDate: item.startDate, // "YYYY.MM.DD"
+    endDate: item.endDate,
+
+    areaName: item.areaName,
+    areaCode: item.areaCode,
+    categoryName: item.categoryName,
+
+    likes: typeof item.favoriteCount === 'number' ? item.favoriteCount : 0, // mock의 likes 대응
+    thumbnail: item.firstImage || item.secondImage || '', // mock의 thumbnail 대응
+    firstImage: item.firstImage || '',
+    secondImage: item.secondImage || '',
+  };
+}
+
+export default function useMainFestivals() {
+  const [upcoming, setUpcoming] = useState([]); // 따끈따끈 신규
+  const [endingSoon, setEndingSoon] = useState([]); // 마감 임박
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchAll() {
+      setLoading(true);
+      setError(null);
+      try {
+        const [upRes, endRes] = await Promise.all([
+          axiosInstance.get('event/upcoming'),
+          axiosInstance.get('event/ending-soon'),
+        ]);
+
+        const up = (upRes?.data?.content || []).map(normalizeFestival);
+        const end = (endRes?.data?.content || []).map(normalizeFestival);
+
+        if (!mounted) return;
+        setUpcoming(up);
+        setEndingSoon(end);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e);
+      } finally {
+        if (!mounted) return;
+        setLoading(false);
+      }
+    }
+
+    fetchAll();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { upcoming, endingSoon, loading, error };
+}

--- a/src/hooks/festival/useMainFestivals.js
+++ b/src/hooks/festival/useMainFestivals.js
@@ -1,26 +1,23 @@
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 
-// API 응답 → 카드에서 쓰기 좋은 형태로 정규화
 function normalizeFestival(item) {
   return {
-    id: item.eventId, // 기존 mock의 id 대체
+    id: item.eventId,
     eventId: item.eventId,
     contentId: item.contentId,
 
     title: item.title,
-    location: item.addr1 ?? '', // mock의 location 대응
-    startDate: item.startDate, // "YYYY.MM.DD"
+    location: item.addr1 ?? '',
+    startDate: item.startDate,
     endDate: item.endDate,
 
     areaName: item.areaName,
     areaCode: item.areaCode,
     categoryName: item.categoryName,
 
-    likes: typeof item.favoriteCount === 'number' ? item.favoriteCount : 0, // mock의 likes 대응
-    thumbnail: item.firstImage || item.secondImage || '', // mock의 thumbnail 대응
-    firstImage: item.firstImage || '',
-    secondImage: item.secondImage || '',
+    likes: typeof item.favoriteCount === 'number' ? item.favoriteCount : 0,
+    thumbnail: item.firstImage || item.secondImage || '',
   };
 }
 
@@ -52,8 +49,7 @@ export default function useMainFestivals() {
         if (!mounted) return;
         setError(e);
       } finally {
-        if (!mounted) return;
-        setLoading(false);
+        if (mounted) setLoading(false);
       }
     }
 

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -1,22 +1,22 @@
+// lib/axiosInstance.js
 import axios from 'axios';
 
-const DEV_ACCESS = process.env.NEXT_PUBLIC_API_ACCESS_TOKEN || '';
-const DEV_REFRESH = process.env.NEXT_PUBLIC_API_REFRESH_TOKEN || '';
+function readTokens() {
+  if (typeof window === 'undefined')
+    return { access: '', refresh: '', kind: null };
+  const la = localStorage.getItem('access_token');
+  const lr = localStorage.getItem('refresh_token');
+  if (lr) return { access: la || '', refresh: lr, kind: 'local' };
+  const sa = sessionStorage.getItem('access_token');
+  const sr = sessionStorage.getItem('refresh_token');
+  if (sr) return { access: sa || '', refresh: sr, kind: 'session' };
+  return { access: '', refresh: '', kind: null };
+}
 
-let isRefreshing = false;
-let queue = [];
-
-// 새 액세스 토큰 발급
-async function refreshAccessToken() {
-  const res = await axios.post(
-    '/api/auth/reissue',
-    { refreshToken: DEV_REFRESH },
-    { withCredentials: false }
-  );
-  const content = res.data?.content || {};
-  const newAccess = content.accessToken;
-  if (!newAccess) throw new Error('No access token in refresh response');
-  return newAccess;
+function saveAccess(token, kind) {
+  if (typeof window === 'undefined') return;
+  if (kind === 'local') localStorage.setItem('access_token', token);
+  if (kind === 'session') sessionStorage.setItem('access_token', token);
 }
 
 const axiosInstance = axios.create({
@@ -26,57 +26,63 @@ const axiosInstance = axios.create({
   headers: { Accept: 'application/json' },
 });
 
-// 요청 인터셉터
+// 요청 인터셉터: 세션에 토큰이 있을 때만 Authorization 부착
 axiosInstance.interceptors.request.use((config) => {
-  const token =
-    (typeof window !== 'undefined' &&
-      (localStorage.getItem('access_token') ||
-        sessionStorage.getItem('access_token'))) ||
-    DEV_ACCESS;
-  if (token) {
+  const { access } = readTokens();
+  if (access) {
     config.headers = config.headers || {};
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = `Bearer ${access}`;
   }
   return config;
 });
 
-// 응답 인터셉터
+// 응답 인터셉터: 401이면 리프레시 시도 후 원요청 재시도
 axiosInstance.interceptors.response.use(
   (res) => res,
   async (err) => {
     const original = err.config || {};
-    if (err?.response?.status !== 401 || original._retry) {
-      return Promise.reject(err);
-    }
+    if (original._skipAuthRefresh) return Promise.reject(err);
+    if (err?.response?.status !== 401 || original._retry) return Promise.reject(err);
 
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        queue.push({ resolve, reject });
-      }).then((token) => {
-        original.headers.Authorization = `Bearer ${token}`;
-        return axiosInstance(original);
-      });
-    }
+    const { refresh, kind } = readTokens();
+    if (!refresh) return Promise.reject(err);
 
-    isRefreshing = true;
     original._retry = true;
-
     try {
-      const newToken = await refreshAccessToken();
-      localStorage.setItem('access_token', newToken);
-      queue.forEach((p) => p.resolve(newToken));
-      queue = [];
+      const re = await axios.post(
+        '/api/auth/reissue',
+        { refreshToken: refresh },
+        { headers: { 'Content-Type': 'application/json' }, withCredentials: false, _skipAuthRefresh: true }
+      );
 
-      original.headers.Authorization = `Bearer ${newToken}`;
+      const newAccess = re.data?.content?.accessToken;
+
+      // 여기서 더 이상 throw 하지 않음
+      if (!newAccess) {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('access_token');
+          localStorage.removeItem('refresh_token');
+          sessionStorage.removeItem('access_token');
+          sessionStorage.removeItem('refresh_token');
+        }
+        return Promise.reject(new Error('No access token in refresh response'));
+      }
+
+      saveAccess(newAccess, kind);
+      original.headers = original.headers || {};
+      original.headers.Authorization = `Bearer ${newAccess}`;
       return axiosInstance(original);
     } catch (e) {
-      queue.forEach((p) => p.reject(e));
-      queue = [];
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        sessionStorage.removeItem('access_token');
+        sessionStorage.removeItem('refresh_token');
+      }
       return Promise.reject(e);
-    } finally {
-      isRefreshing = false;
     }
   }
 );
+
 
 export default axiosInstance;

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -9,7 +9,7 @@ let queue = [];
 // 새 액세스 토큰 발급
 async function refreshAccessToken() {
   const res = await axios.post(
-    `'/api/auth/reissue`,
+    '/api/auth/reissue',
     { refreshToken: DEV_REFRESH },
     { withCredentials: false }
   );

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -1,4 +1,3 @@
-// lib/axiosInstance.js
 import axios from 'axios';
 
 function readTokens() {
@@ -42,7 +41,8 @@ axiosInstance.interceptors.response.use(
   async (err) => {
     const original = err.config || {};
     if (original._skipAuthRefresh) return Promise.reject(err);
-    if (err?.response?.status !== 401 || original._retry) return Promise.reject(err);
+    if (err?.response?.status !== 401 || original._retry)
+      return Promise.reject(err);
 
     const { refresh, kind } = readTokens();
     if (!refresh) return Promise.reject(err);
@@ -52,12 +52,15 @@ axiosInstance.interceptors.response.use(
       const re = await axios.post(
         '/api/auth/reissue',
         { refreshToken: refresh },
-        { headers: { 'Content-Type': 'application/json' }, withCredentials: false, _skipAuthRefresh: true }
+        {
+          headers: { 'Content-Type': 'application/json' },
+          withCredentials: false,
+          _skipAuthRefresh: true,
+        }
       );
 
       const newAccess = re.data?.content?.accessToken;
 
-      // 여기서 더 이상 throw 하지 않음
       if (!newAccess) {
         if (typeof window !== 'undefined') {
           localStorage.removeItem('access_token');
@@ -83,6 +86,5 @@ axiosInstance.interceptors.response.use(
     }
   }
 );
-
 
 export default axiosInstance;

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 const DEV_ACCESS = process.env.NEXT_PUBLIC_API_ACCESS_TOKEN || '';
 const DEV_REFRESH = process.env.NEXT_PUBLIC_API_REFRESH_TOKEN || '';
 
@@ -10,7 +9,7 @@ let queue = [];
 // 새 액세스 토큰 발급
 async function refreshAccessToken() {
   const res = await axios.post(
-    `${API_BASE_URL}auth/reissue`,
+    `'/api/auth/reissue`,
     { refreshToken: DEV_REFRESH },
     { withCredentials: false }
   );
@@ -21,7 +20,7 @@ async function refreshAccessToken() {
 }
 
 const axiosInstance = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: '/api/',
   withCredentials: false,
   timeout: 15000,
   headers: { Accept: 'application/json' },

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -1,0 +1,83 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const DEV_ACCESS = process.env.NEXT_PUBLIC_API_ACCESS_TOKEN || '';
+const DEV_REFRESH = process.env.NEXT_PUBLIC_API_REFRESH_TOKEN || '';
+
+let isRefreshing = false;
+let queue = [];
+
+// 새 액세스 토큰 발급
+async function refreshAccessToken() {
+  const res = await axios.post(
+    `${API_BASE_URL}auth/reissue`,
+    { refreshToken: DEV_REFRESH },
+    { withCredentials: false }
+  );
+  const content = res.data?.content || {};
+  const newAccess = content.accessToken;
+  if (!newAccess) throw new Error('No access token in refresh response');
+  return newAccess;
+}
+
+const axiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: false,
+  timeout: 15000,
+  headers: { Accept: 'application/json' },
+});
+
+// 요청 인터셉터
+axiosInstance.interceptors.request.use((config) => {
+  const token =
+    (typeof window !== 'undefined' &&
+      (localStorage.getItem('access_token') ||
+        sessionStorage.getItem('access_token'))) ||
+    DEV_ACCESS;
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 응답 인터셉터
+axiosInstance.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    const original = err.config || {};
+    if (err?.response?.status !== 401 || original._retry) {
+      return Promise.reject(err);
+    }
+
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        queue.push({ resolve, reject });
+      }).then((token) => {
+        original.headers.Authorization = `Bearer ${token}`;
+        return axiosInstance(original);
+      });
+    }
+
+    isRefreshing = true;
+    original._retry = true;
+
+    try {
+      const newToken = await refreshAccessToken();
+      localStorage.setItem('access_token', newToken);
+      queue.forEach((p) => p.resolve(newToken));
+      queue = [];
+
+      original.headers.Authorization = `Bearer ${newToken}`;
+      return axiosInstance(original);
+    } catch (e) {
+      queue.forEach((p) => p.reject(e));
+      queue = [];
+      return Promise.reject(e);
+    } finally {
+      isRefreshing = false;
+    }
+  }
+);
+
+export default axiosInstance;

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,4 @@
 {
   "version": 2,
-  "outputDirectory": "out",
-  "cleanUrls": true,
-  "trailingSlash": true
+  "cleanUrls": true
 }


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes Dori-Room#16
Closes Dori-Room#18
Closes Dori-Room#19

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
## 1. 배포방식 변화 및 api 연결을 위한 환경 세팅

### 1-1. 정적 배포에서 동적 세그먼트 라우팅으로 변경

초기에는 앱을 안드로이드 WebView로 감싸는 하이브리드 구조에서 빌드 타임에 모든 경로를 고정적으로 생성하는 방식이 가장 단순하고 빠르게 배포되었기 때문에 정적 export 방식을 사용했습니다. HTML을 미리 만들어두는 방식이 캐시 효율과 로드 타임 면에서도 유리했지만 실제 API 연동이 들어가고 축제데이터 등 id가 수시로 갱신되면서 빌드 시점에 모든 상세 경로를 미리 산출할 수 없는 문제가 생겼습니다. generateStaticParams로 모든 ID를 나열하는 전략이 현실적으로 유지되지 않았고, 빌드 이후 새로 생기는 ID에 대해 404가 발생하는 문제가 확인되었습니다. 이처럼 클라이언트에서 동적으로 데이터를 패칭하는 구조가 필수가 되었기에 App Router의 동적 세그먼트 라우팅으로 전환했습니다. Vercel의 런타임 라우팅을 그대로 활용하여 .next 산출물을 기준으로 경로를 해석하도록 구성했고, 상세 페이지는 CSR로 데이터를 패칭하도록 만들어 신규 Id에 대해 재배포 없이 직접 접근이 가능하도록 했습니다. 

### 1-2. 서버 프록시 추가

백엔드가 HTTP 도메인을 사용하기 때문에 브라우저에서 직접 호출하면 HTTPS 페이지에서 혼합 콘텐츠 차단과 CORS 제약이 동시에 발생했습니다. `app/api/[...path]/route.js`에 Route Handler 프록시를 두어 브라우저는 항상 `https://{our-origin}/api/*`로만 통신하도록 만들었고, 서버는 내부에서 BACKEND_ORIGIN으로 HTTP 요청을 대리 수행하도록 구성했습니다. NEXT_PUBLIC_*로 선언한 값은 번들에 인라인되어 브라우저/소스맵/뷰페이지 소스에서 그대로 보이기 때문에 서버 전용 환경변수를 사용하여 백엔드 주소가 번들과 저장소에 노출되지 않도록 했습니다. 요청과 응답 헤더는 ASCII 화이트리스트 방식으로 선별 전달하여 비 ASCII 헤더로 인한 ByteString 변환 예외를 방지했습니다. 일부 백엔드 및 WAF 환경을 고려하여 x-forwarded-proto, x-forwarded-host, host 헤더를 명시적으로 설정했습니다. 

### 1-3. 클라이언트 HTTP 레이어 구성

공통 HTTP 규칙을 한 곳에서 관리하기 위해 `axiosInstance.js`에서 baseURL, 타임아웃, 공통 헤더, 인증 부착, 401 재발급 재시도, 에러 전파 방식을 구현하였습니다. baseURL을 `/api/`로 고정하여 클라이언트 번들에서 백엔드 절대 도메인이 노출되지 않도록 했으며, 요청 인터셉터는 저장된 액세스 토큰이 존재하는 경우에만 Authorization 헤더를 부착하도록 했습니다. 응답 인터셉터는 401 수신 시 `/api/auth/reissue`로 리프레시 토큰을 제출하여 새로운 접근 토큰을 발급받고 원요청을 재시도하도록 했습니다. 재시도 전에 원요청의 headers.Authorization을 갱신하여 인증 누락을 방지했습니다. 재발급 실패 시 저장된 토큰을 정리하고 Promise.reject로 호출자에 에러를 전달했습니다.

아래 내용 참고하셔서 훅에서 api 연결 구현하시면 됩니다.

```
const res = await axiosInstance.get(`event/detail/${festivalId}`); //api의 '/api/'뒤의 라우팅 주소만 적어서 사용
const apiContent = res.data?.content || null;
```

## 2. API 연동

### 2-1. 축제 메인페이지, 상세페이지  

더미 데이터를 제거하고 축제 메인페이지의 신규 축제와 마감 임박 섹션에서 `/api/event/upcoming`과 `/api/event/ending-soon `엔드포인트를 호출하여 렌더링하도록 변경했습니다. 상세 페이지에서는 useParams로 전달받은 `festivalId`를 useFestivalDetail 훅에 주입하여 `/api/event/detail/{eventId}`를 호출하도록 변경했습니다. 응답 데이터는 각 훅에서 UI 전용 모델로 정규화한 뒤 페이지 및 컴포넌트로만 전달하도록 했습니다. 

훅 파일은 app 디렉터리 외부의 `src/hooks`에 위치하여 라우트 경계와 무관하게 재사용 가능하며 빌드 타임에 불필요한 서버 번들 포함을 피하고 트리 셰이킹과 캐싱 효율을 확보했습니다. 

### 2-2. 개발용 자동 로그인 임시 구현

개발 편의를 위해 고정 테스트 계정 자격 증명으로 /api/auth/login을 호출하는 useSignIn 훅을 구현했습니다. 토큰이 존재하지 않는 경우 훅이 자동으로 로그인 요청을 수행하고 발급받은 accessToken과 refreshToken을 LocalStorage 또는 SessionStorage에 저장하도록 했습니다. 로그인 이후 axiosInstance.defaults.headers.Authorization에 액세스 토큰을 주입하여 이후 요청에서 인증이 자동으로 부착되도록 했습니다. 로그인 실패 시  _skipAuthRefresh 플래그로 리프레시 시도를 차단하고, 응답 검증은 try 블록 외부에서 수행하여 실패 시 Promise.reject로 전파하도록 했습니다. 

이후 로그인 페이지 구현시 자동 로그인 로직을 비활성화하거나 로그인 페이지 진입 동선으로 대체 가능하도록 구조를 분리했습니다.

## 3. 축제 상세 페이지 헤더의 스크롤 기반 디자인 수정

ntersectionObserver를 이용하여 이미지 하단 센티넬을 배치하고 헤더가 이미지 영역을 벗어나는 시점을 감지하도록 구성했습니다. 헤더 배경색과 아이콘 색상 전환 상태를 `isScrolled`로 관리하도록 했습니다. 루트 마진을 헤더 높이만큼 음수로 설정하여 헤더와 맞닿는 순간 자연스럽게 전환되도록 했습니다.

## 4. 검색 페이지 필터링 컴포넌트 구현 및 실시간검색어 클릭 연동

검색 결과페이지에서 지역,분야,정렬,기간에 대한 필터링 컴포넌트 UI를 구현했습니다. 또한 검색 메인페이지에서 실시간 검색어를 클릭하면 해당 키워드가 검색 입력 값으로 반영되고 즉시 검색 결과로 이동하도록 연결했습니다. 

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?