### PR TITLE
feat: 상점 API 연결

### DIFF
--- a/src/app/_components/CategoryItemPanel.js
+++ b/src/app/_components/CategoryItemPanel.js
@@ -3,14 +3,6 @@
 import { useState } from 'react';
 import { GoCircleSlash } from 'react-icons/go';
 import Item from './Item';
-import { FaShirt } from 'react-icons/fa6';
-import {
-  FaHatCowboy,
-  FaShoePrints,
-  FaClock,
-  FaWindowMaximize,
-  FaBoxes,
-} from 'react-icons/fa';
 
 export default function CategoryItemPanel({
   items,
@@ -18,34 +10,37 @@ export default function CategoryItemPanel({
   onItemSelect,
   isShop,
 }) {
-  const [selectedCategoryId, onCategorySelect] = useState(1);
+  const [selectedCategoryId, setSelectedCategoryId] = useState('APPAREL');
   const categoryBtns = [
-    { id: 1, name: '의상', icon: FaShirt },
-    { id: 2, name: '선반', icon: FaBoxes },
-    { id: 3, name: '시계', icon: FaClock },
-    { id: 4, name: '창문', icon: FaWindowMaximize },
-    { id: 5, name: '모자', icon: FaHatCowboy },
-    { id: 6, name: '신발', icon: FaShoePrints },
+    { id: 1, name: '의상', type: 'APPAREL', icon: 'mgc_t_shirt_fill' },
+    {
+      id: 2,
+      name: '소품',
+      type: 'OBJECT',
+      icon: 'mgc_toy_horse_fill',
+    },
+    { id: 3, name: '선반', type: 'SHELF', icon: 'mgc_layout_5_fill' },
+    { id: 4, name: '창문', type: 'WINDOW', icon: 'mgc_curtain_fill' },
+    { id: 5, name: '벽지', type: 'WALL', icon: 'mgc_paint_2_fill' },
+    { id: 6, name: '바닥', type: 'FLOOR', icon: 'mgc_paint_2_fill' },
   ];
 
   return (
     <div className="flex flex-col overflow-y-auto">
       {/* 탭 영역 */}
       <div className="shrink-0 mt-5 flex gap-2 overflow-x-auto scrollbar-hide px-3">
-        {categoryBtns.map(({ id, name, icon: Icon }) => {
-          const isActive = id === selectedCategoryId;
+        {categoryBtns.map(({ id, name, type, icon }) => {
+          const isActive = type === selectedCategoryId;
           return (
             <button
               key={id}
-              onClick={() => onCategorySelect(id)}
+              onClick={() => setSelectedCategoryId(type)}
               className={`shrink-0 flex gap-2 items-center justify-center rounded-t-lg px-5 py-1.5 min-h-[35px] ${
                 isActive ? 'bg-background' : 'bg-neutral-200'
               }`}
             >
-              <Icon
-                className={`text-xl ${
-                  isActive ? 'text-main-100' : 'text-neutral-400'
-                }`}
+              <i
+                className={`${icon} text-xl ${isActive ? 'text-main-100' : 'text-neutral-400'}`}
               />
               <p
                 className={`text-sm font-medium whitespace-nowrap ${
@@ -60,7 +55,7 @@ export default function CategoryItemPanel({
       </div>
 
       {/* 아이템 리스트 */}
-      <div className="overflow-y-auto bg-background px-3 pt-3 pb-[80px] grid grid-cols-3 gap-2 scrollbar-hide">
+      <div className="overflow-y-auto bg-background h-screen px-3 pt-3 pb-[80px] grid grid-cols-3 gap-2 scrollbar-hide">
         {/* 선택 안 함 */}
         {!isShop && (
           <Item
@@ -72,13 +67,13 @@ export default function CategoryItemPanel({
         )}
         {/* 선택된 카테고리 아이템 */}
         {items
-          .filter((item) => item.categoryId === selectedCategoryId)
+          .filter((item) => item.itemType === selectedCategoryId)
           .map((item) => (
             <Item
-              key={item.id}
-              onClick={() => onItemSelect(item.id)}
-              isSelected={selectedItemId === item.id}
-              icon={item.icon}
+              key={item.itemId}
+              onClick={() => onItemSelect(item.itemId)}
+              isSelected={selectedItemId === item.itemId}
+              icon={item.imageUrl}
               name={item.name}
               price={isShop ? item.price : null}
             />

--- a/src/app/_components/Item.js
+++ b/src/app/_components/Item.js
@@ -25,7 +25,7 @@ export default function Item({
       </div>
       {price !== null && (
         <div className="flex items-center justify-center gap-1 rounded-md w-[110px] h-[20px] ring-1 ring-neutral-300/50 text-main-100">
-          <FaFire className="trnsform scale-x-[-1] text-main-100 w-4 h-4" />
+          <FaFire className="trnsform scale-x-[-1] text-main-100 w-3.5 h-3.5" />
           <p className="text-center font-bold text-sm">{price}</p>
         </div>
       )}

--- a/src/app/_components/Item.js
+++ b/src/app/_components/Item.js
@@ -1,12 +1,11 @@
-import { GiShirt } from 'react-icons/gi';
-import { FaLeaf } from 'react-icons/fa';
+import { FaFire } from 'react-icons/fa6';
 
 export default function Item({
   name = '장미 머리띠',
   price,
   onClick,
   isSelected,
-  icon: Icon = GiShirt,
+  icon,
 }) {
   return (
     <div className="flex flex-col items-center gap-2">
@@ -14,7 +13,8 @@ export default function Item({
         onClick={onClick}
         className={`relative rounded-md w-[110px] h-[126px]  ${!isSelected ? 'bg-neutral-100 ring-1 ring-neutral-300/50' : 'bg-main-5 ring-1 ring-main-40'}`}
       >
-        <Icon
+        <img
+          src={icon}
           className={`absolute top-2/5 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-black w-12 h-12 ${name === '선택안함' ? 'opacity-40' : null}`}
         />
         <div className="absolute left-1/2 -bottom-2 transform -translate-x-1/2 -translate-y-1/2 bg-background w-[100px] h-[23px] rounded-lg flex justify-center items-center">
@@ -23,10 +23,10 @@ export default function Item({
           </p>
         </div>
       </div>
-      {price && (
-        <div className="flex items-center justify-center gap-2 rounded-md w-[110px] h-[20px] ring-1 ring-neutral-300/50 text-main-100">
-          <FaLeaf />
-          <p className="text-center font-bold text-[13px]">{price}</p>
+      {price !== null && (
+        <div className="flex items-center justify-center gap-1 rounded-md w-[110px] h-[20px] ring-1 ring-neutral-300/50 text-main-100">
+          <FaFire className="trnsform scale-x-[-1] text-main-100 w-4 h-4" />
+          <p className="text-center font-bold text-sm">{price}</p>
         </div>
       )}
     </div>

--- a/src/app/shop/_components/ConfirmModal.js
+++ b/src/app/shop/_components/ConfirmModal.js
@@ -1,13 +1,33 @@
 'use client';
 
 import usePurchaseInfo from '@/hooks/shop/usePurchaseInfo';
+import usePurchase from '@/hooks/shop/usePurchase';
+import useItemAll from '@/hooks/shop/useItemAll';
 
-export default function ConfirmModal({ isOpen, setIsOpen, itemId }) {
+export default function ConfirmModal({ isOpen, setIsOpen, itemId, refetch }) {
   const { items, loading, error } = usePurchaseInfo(itemId);
+  const { mutate } = usePurchase({
+    onSuccess: async () => {
+      setIsOpen(false);
+      await refetch();
+    },
+    onError: () => {
+      return;
+    },
+  });
 
   if (!isOpen) return null;
 
-  if (loading) return;
+  if (loading) return null;
+
+  async function handleConfirm() {
+    if (items.isBuyable) {
+      await mutate({ itemId });
+    } else {
+      alert('크레딧이 부족합니다.');
+      setIsOpen(false);
+    }
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex justify-center">
@@ -20,7 +40,11 @@ export default function ConfirmModal({ isOpen, setIsOpen, itemId }) {
             남은 도깨비불 : {items.remainingCredit}개
           </p>
           <div className="flex justify-between gap-3">
-            <button className="flex-1 py-2 bg-emerald-500 text-white font-semibold rounded-md">
+            <button
+              className="flex-1 py-2 bg-emerald-500 text-white font-semibold rounded-md"
+              onClick={handleConfirm}
+              disabled={!items.isBuyable}
+            >
               네
             </button>
             <button

--- a/src/app/shop/_components/ConfirmModal.js
+++ b/src/app/shop/_components/ConfirmModal.js
@@ -1,39 +1,35 @@
 'use client';
 
-export default function ConfirmModal({
-  isOpen,
-  onConfirm,
-  setIsOpen,
-  credit,
-  price,
-  name,
-}) {
+import usePurchaseInfo from '@/hooks/shop/usePurchaseInfo';
+
+export default function ConfirmModal({ isOpen, setIsOpen, itemId }) {
+  const { items, loading, error } = usePurchaseInfo(itemId);
+
   if (!isOpen) return null;
+
+  if (loading) return;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-center">
       <div className="w-full max-w-[390px] bg-black/30 px-4 flex items-center justify-center">
         <div className="flex flex-col gap-4 bg-white rounded-lg shadow-lg w-[90%] max-w-sm px-10 py-6 animate-fade-in">
-        <p className="text-center text-gray-800 text-base font-semibold">
-          {price} 도깨비불로 {name}을(를) 구매하시겠습니까?
-        </p>
-        <p className="text-center text-neutral-500 font-regular text-[13px] mb-2 ">
-          남은 도깨비불 : {credit-price}개
-        </p>
-        <div className="flex justify-between gap-3">
-          <button
-            onClick={onConfirm}
-            className="flex-1 py-2 bg-emerald-500 text-white font-semibold rounded-md"
-          >
-            네
-          </button>
-          <button
-            onClick={() => setIsOpen(false)}
-            className="flex-1 py-2 bg-emerald-500/5 text-emerald-500 font-semibold rounded-md"
-          >
-            아니요
-          </button>
-        </div>
+          <p className="text-center text-gray-800 text-base font-semibold">
+            {items.price} 도깨비불로 {items.name}을(를) 구매하시겠습니까?
+          </p>
+          <p className="text-center text-neutral-500 font-regular text-[13px] mb-2 ">
+            남은 도깨비불 : {items.remainingCredit}개
+          </p>
+          <div className="flex justify-between gap-3">
+            <button className="flex-1 py-2 bg-emerald-500 text-white font-semibold rounded-md">
+              네
+            </button>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="flex-1 py-2 bg-emerald-500/5 text-emerald-500 font-semibold rounded-md"
+            >
+              아니요
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -1,112 +1,22 @@
 'use client';
 
 import { useState } from 'react';
-import { FaFire, FaShirt } from 'react-icons/fa6';
-import {
-  FaHatCowboy,
-  FaShoePrints,
-  FaClock,
-  FaWindowMaximize,
-  FaBoxes,
-} from 'react-icons/fa';
+import { FaFire } from 'react-icons/fa6';
 import { RiWallet3Fill } from 'react-icons/ri';
 import ConfirmModal from '@/app/shop/_components/ConfirmModal';
 import CategoryItemPanel from '../_components/CategoryItemPanel';
-
-const dummyItems = [
-  // 👕 의상
-  { id: 101, name: '레트로 셔츠', price: 12000, icon: FaShirt, categoryId: 1 },
-  {
-    id: 102,
-    name: '스트라이프 후드',
-    price: 15000,
-    icon: FaShirt,
-    categoryId: 1,
-  },
-  { id: 103, name: '여름 반팔티', price: 8000, icon: FaShirt, categoryId: 1 },
-  { id: 104, name: '청바지', price: 17000, icon: FaShirt, categoryId: 1 },
-  { id: 105, name: '니트 가디건', price: 20000, icon: FaShirt, categoryId: 1 },
-  { id: 106, name: '롱패딩', price: 35000, icon: FaShirt, categoryId: 1 },
-
-  // 📦 선반
-  { id: 201, name: '우드 선반', price: 18000, icon: FaBoxes, categoryId: 2 },
-  { id: 202, name: '화이트 선반', price: 20000, icon: FaBoxes, categoryId: 2 },
-  {
-    id: 203,
-    name: '4단 메탈 선반',
-    price: 25000,
-    icon: FaBoxes,
-    categoryId: 2,
-  },
-
-  // 🕰 시계
-  { id: 301, name: '벽걸이 시계', price: 12000, icon: FaClock, categoryId: 3 },
-  {
-    id: 302,
-    name: '엔틱 탁상시계',
-    price: 16000,
-    icon: FaClock,
-    categoryId: 3,
-  },
-
-  // 🪟 창문
-  {
-    id: 401,
-    name: '블라인드 창문',
-    price: 22000,
-    icon: FaWindowMaximize,
-    categoryId: 4,
-  },
-  {
-    id: 402,
-    name: '투명 유리창',
-    price: 18000,
-    icon: FaWindowMaximize,
-    categoryId: 4,
-  },
-  {
-    id: 403,
-    name: '하얀 프레임 창문',
-    price: 24000,
-    icon: FaWindowMaximize,
-    categoryId: 4,
-  },
-  {
-    id: 404,
-    name: '알루미늄 창문',
-    price: 21000,
-    icon: FaWindowMaximize,
-    categoryId: 4,
-  },
-
-  // 🤠 모자
-  {
-    id: 501,
-    name: '카우보이 모자',
-    price: 9000,
-    icon: FaHatCowboy,
-    categoryId: 5,
-  },
-  { id: 502, name: '비니', price: 7000, icon: FaHatCowboy, categoryId: 5 },
-  { id: 503, name: '버킷햇', price: 10000, icon: FaHatCowboy, categoryId: 5 },
-
-  // 👟 신발
-  { id: 601, name: '운동화', price: 11000, icon: FaShoePrints, categoryId: 6 },
-  { id: 602, name: '부츠', price: 15000, icon: FaShoePrints, categoryId: 6 },
-  { id: 603, name: '슬리퍼', price: 6000, icon: FaShoePrints, categoryId: 6 },
-  { id: 604, name: '로퍼', price: 13000, icon: FaShoePrints, categoryId: 6 },
-  { id: 605, name: '샌들', price: 9000, icon: FaShoePrints, categoryId: 6 },
-  { id: 606, name: '축구화', price: 17000, icon: FaShoePrints, categoryId: 6 },
-];
+import useItemAll from '@/hooks/shop/useItemAll';
 
 export default function Shop() {
   const [selectedItemIdx, setSelectedItemIdx] = useState(null);
   const [isOpenBuyModal, setIsOpenBuyModal] = useState(false);
+  const { items, loading, error } = useItemAll();
 
   // 유저가 가지고 있는 크레딧
   const credit = 222000;
 
-  const selectedItem = dummyItems.find((item) => item.id === selectedItemIdx);
+  const selectedItem = items.find((item) => item.id === selectedItemIdx);
+
   function handleConfirm() {
     // 현재 이 유저가 가지고 있는 크레딧 조회
     if (credit >= selectedItem.price) {
@@ -153,7 +63,7 @@ export default function Shop() {
         </div>
 
         <CategoryItemPanel
-          items={dummyItems}
+          items={items}
           selectedItemId={selectedItemIdx}
           onItemSelect={setSelectedItemIdx}
           isShop={true}

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FaFire } from 'react-icons/fa6';
 import { RiWallet3Fill } from 'react-icons/ri';
 import ConfirmModal from '@/app/shop/_components/ConfirmModal';
@@ -13,9 +13,9 @@ export default function Shop() {
   const { items, loading, error } = useItemAll();
 
   // 유저가 가지고 있는 크레딧
-  const credit = 222000;
+  const credit = 0;
 
-  const selectedItem = items.find((item) => item.id === selectedItemIdx);
+  const selectedItem = items.find((item) => item.itemId === selectedItemIdx);
 
   function handleConfirm() {
     // 현재 이 유저가 가지고 있는 크레딧 조회
@@ -72,11 +72,8 @@ export default function Shop() {
       {isOpenBuyModal && (
         <ConfirmModal
           isOpen={isOpenBuyModal}
-          onConfirm={handleConfirm}
           setIsOpen={setIsOpenBuyModal}
-          credit={credit}
-          price={selectedItem.price}
-          name={selectedItem.name}
+          itemId={selectedItemIdx}
         />
       )}
     </div>

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -21,10 +21,10 @@ export default function Shop() {
         {/* 상단 고정: 보유 포인트 (왼쪽 정렬) */}
         <div className="sticky flex top-0 z-10 pt-4 pb-2 pl-3">
           <div
-            className="flex justify-center items-center gap-2 py-1 rounded-lg w-auto px-2"
+            className="flex justify-center items-center gap-2 rounded-lg w-auto px-2"
             style={{ boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}
           >
-            <FaFire className="ml-1 trnsform scale-x-[-1] text-main-100 w-5 h-5" />
+            <FaFire className="trnsform scale-x-[-1] text-main-100 w-5 h-5" />
             <p className="font-bold text-main-100 text-lg">{credit}</p>
           </div>
         </div>

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FaFire } from 'react-icons/fa6';
 import { RiWallet3Fill } from 'react-icons/ri';
 import ConfirmModal from '@/app/shop/_components/ConfirmModal';
@@ -10,28 +10,14 @@ import useItemAll from '@/hooks/shop/useItemAll';
 export default function Shop() {
   const [selectedItemIdx, setSelectedItemIdx] = useState(null);
   const [isOpenBuyModal, setIsOpenBuyModal] = useState(false);
-  const { items, loading, error } = useItemAll();
+  const { items, loading, error, refetch } = useItemAll();
 
   // 유저가 가지고 있는 크레딧
   const credit = 0;
 
-  const selectedItem = items.find((item) => item.itemId === selectedItemIdx);
-
-  function handleConfirm() {
-    // 현재 이 유저가 가지고 있는 크레딧 조회
-    if (credit >= selectedItem.price) {
-      // 구매 요청 API 호출
-      alert('구매가 완료되었습니다.');
-      setIsOpenBuyModal(false);
-    } else {
-      alert('크레딧이 부족합니다.');
-      setIsOpenBuyModal(false);
-    }
-  }
-
   return (
     <div className="flex justify-center h-screen pt-[30px] bg-neutral-100">
-      <div className="flex flex-col max-w-[390px] mx-auto">
+      <div className="flex flex-col max-w-[390px] w-screen mx-auto">
         {/* 상단 고정: 보유 포인트 (왼쪽 정렬) */}
         <div className="sticky flex top-0 z-10 pt-4 pb-2 pl-3">
           <div
@@ -61,19 +47,23 @@ export default function Shop() {
             <p className="font-bold text-[14px]">구입하기</p>
           </button>
         </div>
-
-        <CategoryItemPanel
-          items={items}
-          selectedItemId={selectedItemIdx}
-          onItemSelect={setSelectedItemIdx}
-          isShop={true}
-        />
+        {loading ? (
+          <div>불러오는중...</div>
+        ) : (
+          <CategoryItemPanel
+            items={items}
+            selectedItemId={selectedItemIdx}
+            onItemSelect={setSelectedItemIdx}
+            isShop={true}
+          />
+        )}
       </div>
       {isOpenBuyModal && (
         <ConfirmModal
           isOpen={isOpenBuyModal}
           setIsOpen={setIsOpenBuyModal}
           itemId={selectedItemIdx}
+          refetch={refetch}
         />
       )}
     </div>

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 
 function normalizeItem(item) {
@@ -20,31 +20,34 @@ export default function useItemAll() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    let mounted = true;
+  const mountedRef = useRef(true);
 
-    async function fetchAll() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await axiosInstance.get('items');
-        const apiContent = (res.data?.content || []).map(normalizeItem);
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
 
-        if (!mounted) return;
-        setItems(apiContent.filter((item) => !item.isOwned));
-      } catch (e) {
-        if (!mounted) return;
-        setError(e);
-      } finally {
-        if (mounted) setLoading(false);
-      }
+    try {
+      const res = await axiosInstance.get('items');
+      const apiContent = (res.data?.content || []).map(normalizeItem);
+
+      if (!mountedRef.current) return;
+      setItems(apiContent.filter((item) => !item.isOwned));
+    } catch (e) {
+      if (!mountedRef.current) return;
+      setError(e);
+    } finally {
+      if (mountedRef.current) setLoading(false);
     }
-
-    fetchAll();
-    return () => {
-      mounted = false;
-    };
   }, []);
 
-  return { items, loading, error };
+  useEffect(() => {
+    mountedRef.current = true;
+    refetch();
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [refetch]);
+
+  return { items, loading, error, refetch };
 }

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+function normalizeItem(item) {
+  return {
+    itemId: item.itemId,
+    name: item.name,
+    imageUrl: item.imageUrl,
+    itemType: item.itemType,
+    itemGroup: item.itemGroup,
+    areaGroup: item.areaGroup,
+    price: item.price,
+    isPurchasable: item.isPurchasable,
+    isOwned: item.isOwned,
+  };
+}
+
+export default function useItemAll() {
+  const [items, setItems] = useState([]); // 마감 임박
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchAll() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await axiosInstance.get('items');
+        const apiContent = (res.data?.content || []).map(normalizeItem);
+
+        if (!mounted) return;
+        setItems(apiContent.filter((item) => !item.isOwned));
+      } catch (e) {
+        if (!mounted) return;
+        setError(e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    fetchAll();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { items, loading, error };
+}

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -16,7 +16,7 @@ function normalizeItem(item) {
 }
 
 export default function useItemAll() {
-  const [items, setItems] = useState([]); // 마감 임박
+  const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 

--- a/src/hooks/shop/usePurchase.js
+++ b/src/hooks/shop/usePurchase.js
@@ -1,0 +1,61 @@
+'use client';
+
+import axiosInstance from '@/lib/axiosInstance';
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+function normalizePurchase(api) {
+  if (!api) return null;
+  return {
+    itemId: api.itemId,
+    name: api.name,
+    price: api.price,
+    remainingCredit: api.remainingCredit,
+  };
+}
+
+export default function usePurchase(handler) {
+  const { onSuccess, onError } = handler;
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = true;
+    };
+  }, []);
+
+  const mutate = useCallback(
+    async ({ itemId }) => {
+      if (!itemId) return;
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await axiosInstance.post('items/purchase', {
+          itemId,
+        });
+
+        const apiContent = res.data?.content || null;
+        if (!mountedRef.current) return;
+        onSuccess?.();
+        setData(normalizePurchase(apiContent));
+      } catch (err) {
+        if (!mountedRef.current) return;
+        onError?.();
+        setError(err);
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    },
+    [loading, onSuccess, onError]
+  );
+
+  const reset = () => {
+    setData(null);
+    setError(null);
+  };
+
+  return { mutate, data, loading, error, reset };
+}

--- a/src/hooks/shop/usePurchaseInfo.js
+++ b/src/hooks/shop/usePurchaseInfo.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+function normalizeItem(item) {
+  return {
+    name: item.name,
+    price: item.price,
+    remainingCredit: item.remainingCredit,
+    isBuyable: item.isBuyable,
+  };
+}
+
+export default function usePurchaseInfo(itemId) {
+  const [items, setItems] = useState([]); // 마감 임박
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchDetail() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await axiosInstance.get(`items/purchase/${itemId}`);
+        const apiContent = res.data?.content || null;
+
+        if (!mounted) return;
+        setItems(normalizeItem(apiContent));
+      } catch (e) {
+        if (!mounted) return;
+        setError(e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    fetchDetail();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { items, loading, error };
+}


### PR DESCRIPTION
# 🔗 관련 이슈
Closes Dori-room#20

---

# ✨ 작업 사항
### 1. 전체 Item API 적용 /api/items
처음 상점 페이지를 들어갈 경우 전체 아이템 조회 API를 활용하여 아이템 목록을 유형별로 보여줍니다. refetch 콜백함수를 통해 추후 아이템 구매 후, 아이템 목록 refetch를 진행합니다.

### 2. 아이템 구매 전 결과 API 모달창 적용 /api/items/purchase/{itemId}
아이템을 선택 후 구매하기 버튼이 활성화되었을 때 클릭할 경우 구매 후 남는 크레딧, 구매 가능 여부, 물건 이름, 가격의 정보가 담겨있는 모달창을 띄웁니다. 현재 로직은 구매하지 못하더라도 모달창이 뜨고, 구매 버튼을 disabled 해놓았습니다. 그러나 추후 디자인이 추가되면 구매가 불가능한 경우 아예 모달창이 뜨지 않게끔 구현할 예정입니다.

### 3. 아이템 구매 API 적용 /api/items/purchase
모달창에서 '예' 버튼을 클릭할 경우, 해당 아이템을 구매하는 API를 호출한 후, 전체 Item 목록을 불러오는 API를 refetch하여 유저에게 보여줍니다.

---

# 📸 스크린샷 (선택)


---

# 🔗 참고 자료 (선택)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 현재 이미지는 따로 들어있지 않아서 빈 화면으로 보입니다. 참고 부탁드리겠습니다.
- loading을 이용해서 전체 화면에 로딩창이 적용되는 것이 아닌 아이템 목록 UI에 로딩이 적용되도록 설정해놓았습니다.
- API 연결된 것에 오류나 수정사항이 있는지 중점적으로 봐주시면 감사드리겠습니다.
- 그리고 현재 보유한 Credit 정보를 가져올 수 있는 API가 개발 전이여서 연결해놓지 못한 상태입니다. 개발되는대로 추가해놓겠습니다.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?