### PR TITLE
feat: 상점 페이지 기능 추가

### DIFF
--- a/src/app/_components/CategoryItemPanel.js
+++ b/src/app/_components/CategoryItemPanel.js
@@ -76,6 +76,7 @@ export default function CategoryItemPanel({
               icon={item.imageUrl}
               name={item.name}
               price={isShop ? item.price : null}
+              isOwned={item.isOwned}
             />
           ))}
       </div>

--- a/src/app/_components/Item.js
+++ b/src/app/_components/Item.js
@@ -24,7 +24,7 @@ export default function Item({
           </div>
         )}
         {isOwned && (
-          <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-100" />
+          <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-10" />
         )}
         <div className="absolute left-1/2 -bottom-2 transform -translate-x-1/2 -translate-y-1/2 bg-background w-[100px] h-[23px] rounded-lg flex justify-center items-center">
           <p className="text-center text-neutral-900 font-semibold text-[13px]">
@@ -37,7 +37,7 @@ export default function Item({
           <FaFire className="trnsform scale-x-[-1] text-main-100 w-3.5 h-3.5" />
           <p className="text-center font-bold text-sm">{price}</p>
           {isOwned && (
-            <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-100" />
+            <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-10" />
           )}
         </div>
       )}

--- a/src/app/_components/Item.js
+++ b/src/app/_components/Item.js
@@ -2,31 +2,43 @@ import { FaFire } from 'react-icons/fa6';
 
 export default function Item({
   name = '장미 머리띠',
-  price,
+  price = null,
   onClick,
   isSelected,
   icon,
+  isOwned,
 }) {
   return (
     <div className="flex flex-col items-center gap-2">
       <div
-        onClick={onClick}
+        onClick={isOwned ? null : onClick}
         className={`relative rounded-md w-[110px] h-[126px]  ${!isSelected ? 'bg-neutral-100 ring-1 ring-neutral-300/50' : 'bg-main-5 ring-1 ring-main-40'}`}
       >
         <img
           src={icon}
           className={`absolute top-2/5 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-black w-12 h-12 ${name === '선택안함' ? 'opacity-40' : null}`}
         />
+        {isOwned && (
+          <div className="absolute top-2/5 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-23 h-23 rounded-full border border-main-100 flex items-center justify-center">
+            <p className="text-main-100 font-bold text-sm">구입완료</p>
+          </div>
+        )}
+        {isOwned && (
+          <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-100" />
+        )}
         <div className="absolute left-1/2 -bottom-2 transform -translate-x-1/2 -translate-y-1/2 bg-background w-[100px] h-[23px] rounded-lg flex justify-center items-center">
-          <p className="text-center text-black font-semibold text-[13px]">
+          <p className="text-center text-neutral-900 font-semibold text-[13px]">
             {name}
           </p>
         </div>
       </div>
       {price !== null && (
-        <div className="flex items-center justify-center gap-1 rounded-md w-[110px] h-[20px] ring-1 ring-neutral-300/50 text-main-100">
+        <div className="relative flex items-center justify-center gap-1 rounded-md w-[110px] h-[20px] ring-1 ring-neutral-300/50 text-main-100">
           <FaFire className="trnsform scale-x-[-1] text-main-100 w-3.5 h-3.5" />
           <p className="text-center font-bold text-sm">{price}</p>
+          {isOwned && (
+            <div className="absolute w-full h-full bg-neutral-100 opacity-40 z-100" />
+          )}
         </div>
       )}
     </div>

--- a/src/app/_providers/ToastProvider.js
+++ b/src/app/_providers/ToastProvider.js
@@ -26,7 +26,7 @@ function genId() {
 }
 
 export default function ToastProvider({ children }) {
-  const [toasts, setToasts] = useState([]); // { id, message, duration?, _state }
+  const [toasts, setToasts] = useState([]); // { id, message, variant, duration?, _state }
   const [mounted, setMounted] = useState(false);
   const timersRef = useRef({});
   const leavingRef = useRef({});
@@ -82,7 +82,10 @@ export default function ToastProvider({ children }) {
   const show = useCallback(
     (input) => {
       const id = genId();
-      const toast = { id, message: input, _state: 'enter' };
+      const toast =
+        typeof input === 'string'
+          ? { id, message: input, _state: 'enter' }
+          : { id, ...input, _state: 'enter' };
 
       setToasts((prev) => [...prev, toast]);
 
@@ -123,7 +126,12 @@ export default function ToastProvider({ children }) {
 }
 
 function ToastItem({ toast }) {
-  const { message, _state = 'idle' } = toast;
+  const { message, variant = 'default', _state = 'idle' } = toast;
+
+  const styles = {
+    default: <></>,
+    purchase: <i className="mgc_check_circle_fill text-main-100" />,
+  };
 
   const anim =
     _state === 'enter'
@@ -140,7 +148,8 @@ function ToastItem({ toast }) {
       `}
     >
       <div className="flex items-center justify-center gap-3">
-        <div className="text-base font-normal leading-5 whitespace-pre-line">
+        {styles[variant]}
+        <div className="text-sm font-normal text-background leading-5 whitespace-pre-line">
           {message}
         </div>
       </div>

--- a/src/app/_providers/ToastProvider.js
+++ b/src/app/_providers/ToastProvider.js
@@ -1,0 +1,149 @@
+'use client';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+const ANIM_MS = 220; // 입/퇴장 애니메이션 길이(ms)
+const ToastContext = createContext(null);
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within <ToastProvider>');
+  return ctx;
+};
+
+function genId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID)
+    return crypto.randomUUID();
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export default function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]); // { id, message, duration?, _state }
+  const [mounted, setMounted] = useState(false);
+  const timersRef = useRef({});
+  const leavingRef = useRef({});
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    return () => {
+      Object.values(timersRef.current).forEach(clearTimeout);
+      Object.values(leavingRef.current).forEach(clearTimeout);
+      timersRef.current = {};
+      leavingRef.current = {};
+    };
+  }, []);
+
+  const dismissHard = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const dismiss = useCallback(
+    (id) => {
+      if (timersRef.current[id]) {
+        clearTimeout(timersRef.current[id]);
+        delete timersRef.current[id];
+      }
+
+      setToasts((prev) =>
+        prev.map((t) => (t.id === id ? { ...t, _state: 'exit' } : t))
+      );
+
+      leavingRef.current[id] = window.setTimeout(() => {
+        delete leavingRef.current[id];
+        dismissHard(id);
+      }, ANIM_MS);
+    },
+    [dismissHard]
+  );
+
+  const clear = useCallback(() => {
+    const ids = toasts.map((t) => t.id);
+    setToasts((prev) => prev.map((t) => ({ ...t, _state: 'exit' })));
+    ids.forEach((id) => {
+      if (timersRef.current[id]) {
+        clearTimeout(timersRef.current[id]);
+        delete timersRef.current[id];
+      }
+      leavingRef.current[id] = window.setTimeout(() => {
+        delete leavingRef.current[id];
+        dismissHard(id);
+      }, ANIM_MS);
+    });
+  }, [toasts, dismissHard]);
+
+  const show = useCallback(
+    (input) => {
+      const id = genId();
+      const toast = { id, message: input, _state: 'enter' };
+
+      setToasts((prev) => [...prev, toast]);
+
+      requestAnimationFrame(() => {
+        setToasts((prev) =>
+          prev.map((t) => (t.id === id ? { ...t, _state: 'idle' } : t))
+        );
+      });
+
+      const ms = toast.duration ?? 3000;
+      if (ms > 0) {
+        timersRef.current[id] = window.setTimeout(() => dismiss(id), ms);
+      }
+      return id;
+    },
+    [dismiss]
+  );
+
+  const value = useMemo(
+    () => ({ show, dismiss, clear }),
+    [show, dismiss, clear]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {mounted &&
+        createPortal(
+          <div className="pointer-events-none fixed bottom-20 left-1/2 -translate-x-1/2 z-[9999] flex w-full max-w-xs flex-col gap-2">
+            {toasts.map((t) => (
+              <ToastItem key={t.id} toast={t} />
+            ))}
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({ toast }) {
+  const { message, _state = 'idle' } = toast;
+
+  const anim =
+    _state === 'enter'
+      ? 'opacity-0 translate-y-1 scale-95'
+      : _state === 'exit'
+        ? 'opacity-0 translate-y-1 scale-95'
+        : 'opacity-100 translate-y-0 scale-100';
+  return (
+    <div
+      className={`
+        pointer-events-auto bg-[#525252]/70 text-background rounded-full shadow-lg px-4 py-3
+        transform transition-all duration-[${ANIM_MS}ms] ease-out
+        ${anim}
+      `}
+    >
+      <div className="flex items-center justify-center gap-3">
+        <div className="text-base font-normal leading-5 whitespace-pre-line">
+          {message}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,7 @@
 import './globals.css';
 import BottomNavBar from './_components/BottomNavBar';
 import AuthBootstrap from '@/app/_providers/AuthBootstrap';
+import ToastProvider from './_providers/ToastProvider';
 
 export const metadata = {
   title: 'Dori Room',
@@ -18,7 +19,9 @@ export default function RootLayout({ children }) {
             className="flex-1 bg-background overflow-y-auto scrollbar-hide w-max"
           >
             <div className="h-full pb-18">
-              <AuthBootstrap>{children}</AuthBootstrap>
+              <AuthBootstrap>
+                <ToastProvider>{children}</ToastProvider>
+              </AuthBootstrap>
             </div>
           </main>
           <BottomNavBar />

--- a/src/app/shop/_components/ConfirmModal.js
+++ b/src/app/shop/_components/ConfirmModal.js
@@ -2,10 +2,11 @@
 
 import usePurchaseInfo from '@/hooks/shop/usePurchaseInfo';
 import usePurchase from '@/hooks/shop/usePurchase';
-import useItemAll from '@/hooks/shop/useItemAll';
+import { useToast } from '@/app/_providers/ToastProvider';
 
 export default function ConfirmModal({ isOpen, setIsOpen, itemId, refetch }) {
   const { items, loading, error } = usePurchaseInfo(itemId);
+  const { show } = useToast();
   const { mutate } = usePurchase({
     onSuccess: async () => {
       setIsOpen(false);
@@ -23,8 +24,14 @@ export default function ConfirmModal({ isOpen, setIsOpen, itemId, refetch }) {
   async function handleConfirm() {
     if (items.isBuyable) {
       await mutate({ itemId });
+      show({
+        message: `'${items.name}' 아이템을 구입하였어요!`,
+        variant: 'purchase',
+      });
     } else {
-      alert('크레딧이 부족합니다.');
+      show({
+        message: '앗, 도깨비불이 부족해서 구입할 수 없어요!',
+      });
       setIsOpen(false);
     }
   }

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -6,14 +6,18 @@ import { RiWallet3Fill } from 'react-icons/ri';
 import ConfirmModal from '@/app/shop/_components/ConfirmModal';
 import CategoryItemPanel from '../_components/CategoryItemPanel';
 import useItemAll from '@/hooks/shop/useItemAll';
+import { useToast } from '../_providers/ToastProvider';
 
 export default function Shop() {
   const [selectedItemIdx, setSelectedItemIdx] = useState(null);
   const [isOpenBuyModal, setIsOpenBuyModal] = useState(false);
   const { items, loading, error, refetch } = useItemAll();
+  const { show } = useToast();
 
   // 유저가 가지고 있는 크레딧
   const credit = 0;
+
+  const selectedItem = items.find((item) => item.itemId === selectedItemIdx);
 
   return (
     <div className="flex justify-center h-screen pt-[30px] bg-neutral-100">
@@ -40,8 +44,14 @@ export default function Shop() {
         <div className="flex justify-end my-5 pr-3 text-background">
           <button
             disabled={selectedItemIdx === null}
-            className={`flex gap-2 items-center justify-center rounded-xl px-4 py-2 ${selectedItemIdx === null ? 'bg-neutral-300' : 'bg-main-100'}`}
-            onClick={() => setIsOpenBuyModal(true)}
+            className={`flex gap-2 items-center justify-center rounded-xl px-4 py-2 ${selectedItemIdx === null || credit - selectedItem.price < 0 ? 'bg-neutral-300' : 'bg-main-100'}`}
+            onClick={() => {
+              if (credit - selectedItem.price >= 0) setIsOpenBuyModal(true);
+              else
+                show({
+                  message: '앗, 도깨비불이 부족해서 구입할 수 없어요!',
+                });
+            }}
           >
             <RiWallet3Fill className="fill-background" size={20} />
             <p className="font-bold text-[14px]">구입하기</p>

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -7,15 +7,14 @@ import ConfirmModal from '@/app/shop/_components/ConfirmModal';
 import CategoryItemPanel from '../_components/CategoryItemPanel';
 import useItemAll from '@/hooks/shop/useItemAll';
 import { useToast } from '../_providers/ToastProvider';
+import useMyCredit from '@/hooks/user/useMyCredit';
 
 export default function Shop() {
   const [selectedItemIdx, setSelectedItemIdx] = useState(null);
   const [isOpenBuyModal, setIsOpenBuyModal] = useState(false);
-  const { items, loading, error, refetch } = useItemAll();
+  const { items, loading: IALoaing, error: IAError, refetch } = useItemAll();
+  const { credit, loading: MYLoading, error: MCError } = useMyCredit();
   const { show } = useToast();
-
-  // 유저가 가지고 있는 크레딧
-  const credit = 0;
 
   const selectedItem = items.find((item) => item.itemId === selectedItemIdx);
 
@@ -29,10 +28,11 @@ export default function Shop() {
             style={{ boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}
           >
             <FaFire className="trnsform scale-x-[-1] text-main-100 w-5 h-5" />
-            <p className="font-bold text-main-100 text-lg">{credit}</p>
+            <p className="font-bold text-main-100 text-lg">
+              {MYLoading ? '' : credit}
+            </p>
           </div>
         </div>
-
         {/* 캐릭터 */}
         <div className="shrink-0 mt-20 flex justify-center">
           <img
@@ -57,7 +57,7 @@ export default function Shop() {
             <p className="font-bold text-[14px]">구입하기</p>
           </button>
         </div>
-        {loading ? (
+        {IALoaing ? (
           <div>불러오는중...</div>
         ) : (
           <CategoryItemPanel

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -8,6 +8,8 @@ import CategoryItemPanel from '../_components/CategoryItemPanel';
 import useItemAll from '@/hooks/shop/useItemAll';
 import { useToast } from '../_providers/ToastProvider';
 import useMyCredit from '@/hooks/user/useMyCredit';
+import { MdChair } from 'react-icons/md';
+import Link from 'next/link';
 
 export default function Shop() {
   const [selectedItemIdx, setSelectedItemIdx] = useState(null);
@@ -19,18 +21,26 @@ export default function Shop() {
   const selectedItem = items.find((item) => item.itemId === selectedItemIdx);
 
   return (
-    <div className="flex justify-center h-screen pt-[30px] bg-neutral-100">
+    <div className="flex justify-center h-screen pt-21 bg-neutral-100">
       <div className="flex flex-col max-w-[390px] w-screen mx-auto">
         {/* 상단 고정: 보유 포인트 (왼쪽 정렬) */}
-        <div className="sticky flex top-0 z-10 pt-4 pb-2 pl-3">
+        <div className="flex justify-between px-4">
           <div
-            className="flex justify-center items-center gap-2 rounded-lg w-auto px-2"
+            className="flex justify-center items-center gap-2 rounded-lg w-auto px-2 h-8"
             style={{ boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}
           >
             <FaFire className="trnsform scale-x-[-1] text-main-100 w-5 h-5" />
             <p className="font-bold text-main-100 text-lg">
               {MYLoading ? '' : credit}
             </p>
+          </div>
+          <div>
+            <Link href="/home/decorate">
+              <div className="flex flex-col items-center space-y-1">
+                <MdChair className="w-6 h-6 text-[#F36693]" />
+                <span className="text-xs text-[#F36693]">꾸미기</span>
+              </div>
+            </Link>
           </div>
         </div>
         {/* 캐릭터 */}

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -31,7 +31,7 @@ export default function useItemAll() {
       const apiContent = (res.data?.content || []).map(normalizeItem);
 
       if (!mountedRef.current) return;
-      setItems(apiContent.filter((item) => !item.isOwned));
+      setItems(apiContent);
     } catch (e) {
       if (!mountedRef.current) return;
       setError(e);

--- a/src/hooks/user/useMyCredit.js
+++ b/src/hooks/user/useMyCredit.js
@@ -1,0 +1,38 @@
+import { useEffect, useState, useMemo } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+export default function useMyCredit() {
+  const [credit, setCredit] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchCredit() {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await axiosInstance.get('users/me/credit');
+        const apiContent = res.data?.content || null;
+
+        if (!mounted) return;
+        setCredit(apiContent.userCredit);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    fetchCredit();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const data = useMemo(() => credit, [credit]);
+
+  return { credit: data, loading, error };
+}


### PR DESCRIPTION
# 🔗 관련 이슈
Closes Dori-room#29

---

# ✨ 작업 사항
### 1. 커스텀 토스트 컴포넌트 구현
전역 토스트 시스템(ToastProvider)을 추가해 어디서든 useToast()로 show/dismiss/clear를 사용할 수 있게 했습니다.
토스트는 하단 중앙에 포털로 렌더되어 레이아웃/overflow 영향 없이 표시되며, 기본 3초 뒤 자동으로 닫힙니다(duration 조절 가능, 0이면 고정).
입장·퇴장 애니메이션은 _state: 'enter' → 'idle' → 'exit'로 상태를 전환해 페이드 인/아웃으로 자연스럽게 동작합니다(requestAnimationFrame으로 트랜지션 보장, setTimeout으로 제거 타이밍 제어).
레이아웃(app/layout.js)에서 <ToastProvider>로 앱을 감싸고, 페이지/컴포넌트에서는 const { show } = useToast(); 후 show('메시지') 또는 show({ message, variant: 'purchase', duration: 2500 })처럼 호출합니다.
필요 시 반환된 id로 dismiss(id) 호출이나 clear()로 일괄 제거가 가능합니다.
Next.js SSR 안전성을 위해 포털은 마운트 이후에만 렌더하며, 언마운트 시 내부 타이머를 모두 정리해 메모리 누수를 방지합니다.
기본 스타일은 반투명 다크 배경의 pill 형태이고, variant로 아이콘/스타일 확장(예: purchase)이 가능합니다.
향후 성공/오류 등 추가 variant, 진행바, 위치 옵션(top-right 등), 중복 토스트 합치기 등을 확장할 수 있습니다.

### 2. 크레딧 확인 API 
상점에서 현재 유저가 보유하고 있는 크레딧 정보를 확인하기 위해 users/me/credit API를 활용하였습니다.

### 3. 아이템 컴포넌트 수정
이전 구매한 아이템은 상점에 뜨지 않던 것을 변경하였습니다. 이제는 구매한 아이템일 경우에도 상점에 뜨게 되었습니다. 그러나 구매한 아이템은 구매했다는 것을 알리기 위해서 아이템 위에 UI를 추가하였습니다.

### 4. 꾸미기 페이지 이동 아이콘 추가
상점 페이지에서 꾸미기 페이지로 이동할 수 있는 아이콘을 추가하였습니다.
---

# 📸 스크린샷 (선택)
<img width="388" height="873" alt="image" src="https://github.com/user-attachments/assets/74913c0d-7e22-4e4d-871d-b0437b65743c" />
<img width="396" height="873" alt="image" src="https://github.com/user-attachments/assets/28ece8ca-cefe-4377-a7ec-1c81246b0bd7" />


---

# 🔗 참고 자료 (선택)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이전 회의 때 요청된 변경사항과 동일한지 확인부탁드립니다.
- 전역적으로 사용할 수 있게 구현한 토스트 컴포넌트 로직과 코드 확인 부탁드립니다.

---

# 🚀 PR 체크리스트
- [ ] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [ ] 이 PR이 관련된 이슈와 연결되었나요?
- [ ] 팀원들과 논의가 필요한 부분이 있나요?