### PR TITLE
hotfix: refresh 토큰 동시요청 큐잉 처리

### DIFF
--- a/src/app/_providers/AuthBootstrap.js
+++ b/src/app/_providers/AuthBootstrap.js
@@ -1,50 +1,47 @@
-// app/_providers/AuthBootstrap.jsx
 'use client';
 
 import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import axiosInstance from '@/lib/axiosInstance';
-
-function getStoredTokens() {
-  if (typeof window === 'undefined') return null;
-  const la = localStorage.getItem('access_token');
-  const lr = localStorage.getItem('refresh_token');
-  const sa = sessionStorage.getItem('access_token');
-  const sr = sessionStorage.getItem('refresh_token');
-  if ((la && lr) || (sa && sr)) return { accessToken: la || sa };
-  return null;
-}
+import { useAuthStore } from '@/stores/useAuthStore';
 
 export default function AuthBootstrap({ children }) {
   const router = useRouter();
   const pathname = usePathname();
   const [ready, setReady] = useState(false);
 
-  useEffect(() => {
-    let mounted = true;
+  const { getStoredTokens, setTokens, clearTokens } = useAuthStore();
 
+  useEffect(() => {
     const isAuthPage =
-      pathname?.startsWith('/login') ||
-      pathname?.startsWith('/signup');
+      pathname?.startsWith('/login') || pathname?.startsWith('/signup');
 
     const tokens = getStoredTokens();
 
     if (tokens?.accessToken) {
-      axiosInstance.defaults.headers.Authorization = `Bearer ${tokens.accessToken}`;
-      if (mounted) setReady(true);
+      setTokens(tokens.accessToken, tokens.refreshToken, tokens.kind);
+      setReady(true);
       return;
     }
 
     if (!isAuthPage) {
+      clearTokens();
       router.replace('/auth');
-      if (mounted) setReady(true);
-      return;
     }
 
-    if (mounted) setReady(true);
-    return () => { mounted = false; };
-  }, [pathname, router]);
+    setReady(true);
+  }, [pathname, router, getStoredTokens, setTokens, clearTokens]);
 
-  if (!ready) return null;
+  if (!ready) {
+    return (
+      <div className="flex items-center justify-center h-full bg-background">
+        <img
+          src="/images/doriroom_logo.svg"
+          alt="Dori Room"
+          className="w-32 h-32"
+        />
+      </div>
+    );
+  }
+
   return children;
 }

--- a/src/lib/axiosInstance.js
+++ b/src/lib/axiosInstance.js
@@ -1,22 +1,5 @@
 import axios from 'axios';
-
-function readTokens() {
-  if (typeof window === 'undefined')
-    return { access: '', refresh: '', kind: null };
-  const la = localStorage.getItem('access_token');
-  const lr = localStorage.getItem('refresh_token');
-  if (lr) return { access: la || '', refresh: lr, kind: 'local' };
-  const sa = sessionStorage.getItem('access_token');
-  const sr = sessionStorage.getItem('refresh_token');
-  if (sr) return { access: sa || '', refresh: sr, kind: 'session' };
-  return { access: '', refresh: '', kind: null };
-}
-
-function saveAccess(token, kind) {
-  if (typeof window === 'undefined') return;
-  if (kind === 'local') localStorage.setItem('access_token', token);
-  if (kind === 'session') sessionStorage.setItem('access_token', token);
-}
+import { useAuthStore } from '@/stores/useAuthStore';
 
 const axiosInstance = axios.create({
   baseURL: '/api/',
@@ -25,17 +8,34 @@ const axiosInstance = axios.create({
   headers: { Accept: 'application/json' },
 });
 
-// 요청 인터셉터: 세션에 토큰이 있을 때만 Authorization 부착
+// 리프레시 락/큐
+let isRefreshing = false;
+let refreshQueue = [];
+
+async function refreshTokenRequest(refreshToken) {
+  const re = await axios.post(
+    '/api/auth/reissue',
+    { refreshToken },
+    {
+      headers: { 'Content-Type': 'application/json' },
+      withCredentials: false,
+      _skipAuthRefresh: true,
+    }
+  );
+  return re.data?.content;
+}
+
+// 요청 인터셉터
 axiosInstance.interceptors.request.use((config) => {
-  const { access } = readTokens();
-  if (access) {
+  const { accessToken } = useAuthStore.getState();
+  if (accessToken) {
     config.headers = config.headers || {};
-    config.headers.Authorization = `Bearer ${access}`;
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
   return config;
 });
 
-// 응답 인터셉터: 401이면 리프레시 시도 후 원요청 재시도
+// 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (res) => res,
   async (err) => {
@@ -44,45 +44,61 @@ axiosInstance.interceptors.response.use(
     if (err?.response?.status !== 401 || original._retry)
       return Promise.reject(err);
 
-    const { refresh, kind } = readTokens();
-    if (!refresh) return Promise.reject(err);
+    const { refreshToken, kind, setTokens, clearTokens } =
+      useAuthStore.getState();
+    if (!refreshToken) return Promise.reject(err);
 
     original._retry = true;
-    try {
-      const re = await axios.post(
-        '/api/auth/reissue',
-        { refreshToken: refresh },
-        {
-          headers: { 'Content-Type': 'application/json' },
-          withCredentials: false,
-          _skipAuthRefresh: true,
-        }
-      );
 
-      const newAccess = re.data?.content?.accessToken;
+    // 이미 리프레시 중 → 큐에 대기
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        refreshQueue.push({ resolve, reject });
+      })
+        .then((newAccess) => {
+          original.headers = {
+            ...original.headers,
+            Authorization: `Bearer ${newAccess}`,
+          };
+          return axiosInstance(original);
+        })
+        .catch((e) => Promise.reject(e));
+    }
+
+    // 리프레시 시작
+    isRefreshing = true;
+    try {
+      const data = await refreshTokenRequest(refreshToken);
+      const newAccess = data?.accessToken;
+      const newRefresh = data?.refreshToken;
 
       if (!newAccess) {
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem('access_token');
-          localStorage.removeItem('refresh_token');
-          sessionStorage.removeItem('access_token');
-          sessionStorage.removeItem('refresh_token');
-        }
+        clearTokens();
+        refreshQueue.forEach(({ reject }) =>
+          reject(new Error('No access token in refresh response'))
+        );
+        refreshQueue = [];
         return Promise.reject(new Error('No access token in refresh response'));
       }
 
-      saveAccess(newAccess, kind);
-      original.headers = original.headers || {};
-      original.headers.Authorization = `Bearer ${newAccess}`;
+      setTokens(newAccess, newRefresh, kind);
+
+      // 대기중 요청 처리
+      refreshQueue.forEach(({ resolve }) => resolve(newAccess));
+      refreshQueue = [];
+
+      original.headers = {
+        ...original.headers,
+        Authorization: `Bearer ${newAccess}`,
+      };
       return axiosInstance(original);
     } catch (e) {
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('refresh_token');
-        sessionStorage.removeItem('access_token');
-        sessionStorage.removeItem('refresh_token');
-      }
+      clearTokens();
+      refreshQueue.forEach(({ reject }) => reject(e));
+      refreshQueue = [];
       return Promise.reject(e);
+    } finally {
+      isRefreshing = false;
     }
   }
 );

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+export const useAuthStore = create((set) => ({
+  accessToken: null,
+  refreshToken: null,
+  kind: null, // 'local' | 'session'
+
+  // 토큰 저장 (상태 + 스토리지)
+  setTokens: (access, refresh, kind) => {
+    if (typeof window !== 'undefined') {
+      if (kind === 'local') {
+        if (access) localStorage.setItem('access_token', access);
+        if (refresh) localStorage.setItem('refresh_token', refresh);
+      }
+      if (kind === 'session') {
+        if (access) sessionStorage.setItem('access_token', access);
+        if (refresh) sessionStorage.setItem('refresh_token', refresh);
+      }
+    }
+    set({ accessToken: access, refreshToken: refresh, kind });
+  },
+
+  // 토큰 삭제 (상태 + 스토리지)
+  clearTokens: () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('refresh_token');
+      sessionStorage.removeItem('access_token');
+      sessionStorage.removeItem('refresh_token');
+    }
+    set({ accessToken: null, refreshToken: null, kind: null });
+  },
+
+  // 스토리지에서 토큰 읽기
+  getStoredTokens: () => {
+    if (typeof window === 'undefined') return null;
+    const la = localStorage.getItem('access_token');
+    const lr = localStorage.getItem('refresh_token');
+    if (la && lr) return { accessToken: la, refreshToken: lr, kind: 'local' };
+
+    const sa = sessionStorage.getItem('access_token');
+    const sr = sessionStorage.getItem('refresh_token');
+    if (sa && sr) return { accessToken: sa, refreshToken: sr, kind: 'session' };
+
+    return null;
+  },
+}));


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
기존에는 여러 API 요청이 동시에 401을 반환할 경우, 각 요청마다 리프레시 API가 중복 호출되었습니다. 이 과정에서 이미 갱신된 리프레시 토큰이 무효화되어 마지막 요청에서 "존재하지 않는 리프레시 토큰입니다." 에러가 발생했습니다.

리프레시 요청을 큐잉 방식으로 처리하도록 isRefreshing 플래그와 refreshQueue를 추가하여 리프레시 요청을 한 번만 실행하도록 했습니다. 리프레시 중에 들어온 다른 요청들은 큐에 대기시킨 뒤, 새로운 토큰 발급이 완료되면 큐에 있는 요청들을 재시도합니다. 리프레시 실패 시 큐에 대기 중이던 요청들은 모두 실패로 처리되며, 토큰은 초기화됩니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 앱 시작 시 인증 초기화 동안 전체 화면 로딩 화면(로고 포함) 표시로 사용자 경험 개선.

- 버그 수정
  - 자동 토큰 갱신 동시 처리 안정화로 반복 로그인 요구와 예기치 않은 로그아웃 감소.
  - 세션 만료 시 일관되게 로그인 페이지로 리다이렉트되어 혼란 최소화.
  - 네트워크 응답 지연 및 재시도 과정에서 요청이 누락되거나 중복 실행되는 문제 완화.

- 리팩터링
  - 인증 상태와 토큰 관리를 중앙 스토어로 일원화하여 로그인 유지 및 자동 갱신의 신뢰성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->