### PR TITLE
fix: 아이템 DB 변경 적용

### DIFF
--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "keyedBy": "itemId",
-  "generatedAt": "2025-09-01T07:51:19.830877Z",
+  "generatedAt": "2025-09-07T03:34:15.791747Z",
   "defaults": {
     "zIndex": {
       "WALL": 1,
@@ -18,15 +18,14 @@
       "name": "사물함 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "CLASSROOM",
-      "price": null,
+      "price": 0,
       "purchasable": false,
-      "defaultOwned": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/사물함-선반.svg",
         "thumb": "/images/thumb/SHELF/사물함-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -36,15 +35,14 @@
       "name": "굴뚝 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "WINTER",
       "price": 10,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/굴뚝-선반.svg",
         "thumb": "/images/thumb/SHELF/굴뚝-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -54,15 +52,14 @@
       "name": "캠핑의자 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "PICNIC",
       "price": 20,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/캠핑의자-선반.svg",
         "thumb": "/images/thumb/SHELF/캠핑의자-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -72,15 +69,14 @@
       "name": "파라솔 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "SUMMER",
       "price": 30,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/파라솔-선반.svg",
         "thumb": "/images/thumb/SHELF/파라솔-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -90,15 +86,14 @@
       "name": "아이스크림 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "DESSERT",
       "price": 40,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/아이스크림-선반.svg",
         "thumb": "/images/thumb/SHELF/아이스크림-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -108,15 +103,14 @@
       "name": "선물 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "shelf",
+      "slot": "object",
       "theme": "BIRTHDAY",
       "price": 50,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/SHELF/선물-선반.svg",
         "thumb": "/images/thumb/SHELF/선물-선반.svg",
-        "z": 50,
         "ox": 0,
         "oy": 0
       }
@@ -129,12 +123,11 @@
       "slot": "object",
       "theme": "CLASSROOM",
       "price": 10,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/책.svg",
         "thumb": "/images/thumb/OBJECT/책.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -147,12 +140,11 @@
       "slot": "object",
       "theme": "WINTER",
       "price": 20,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/이글루.svg",
         "thumb": "/images/thumb/OBJECT/이글루.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -165,12 +157,11 @@
       "slot": "object",
       "theme": "PICNIC",
       "price": 30,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/사과바구니.svg",
         "thumb": "/images/thumb/OBJECT/사과바구니.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -183,12 +174,11 @@
       "slot": "object",
       "theme": "SUMMER",
       "price": 40,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/해바라기.svg",
         "thumb": "/images/thumb/OBJECT/해바라기.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -201,12 +191,11 @@
       "slot": "object",
       "theme": "DESSERT",
       "price": 50,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/사탕다발.svg",
         "thumb": "/images/thumb/OBJECT/사탕다발.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -219,12 +208,11 @@
       "slot": "object",
       "theme": "BIRTHDAY",
       "price": 60,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/OBJECT/풍선개.svg",
         "thumb": "/images/thumb/OBJECT/풍선개.svg",
-        "z": 70,
         "ox": 0,
         "oy": 0
       }
@@ -234,15 +222,14 @@
       "name": "비행기 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "CLASSROOM",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 10,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/비행기-창문.svg",
         "thumb": "/images/thumb/WINDOW/비행기-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -252,15 +239,14 @@
       "name": "눈밭 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "WINTER",
-      "price": 10,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 20,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/눈밭-창문.svg",
         "thumb": "/images/thumb/WINDOW/눈밭-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -270,15 +256,14 @@
       "name": "자연 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "PICNIC",
-      "price": 20,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 30,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/자연-창문.svg",
         "thumb": "/images/thumb/WINDOW/자연-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -288,15 +273,14 @@
       "name": "야자수 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "SUMMER",
-      "price": 30,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 40,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/야자수-창문.svg",
         "thumb": "/images/thumb/WINDOW/야자수-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -306,15 +290,14 @@
       "name": "초콜릿 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "DESSERT",
-      "price": 40,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 50,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/초콜릿-창문.svg",
         "thumb": "/images/thumb/WINDOW/초콜릿-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -324,15 +307,14 @@
       "name": "전구 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": "BIRTHDAY",
-      "price": 50,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 60,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WINDOW/전구-창문.svg",
         "thumb": "/images/thumb/WINDOW/전구-창문.svg",
-        "z": 45,
         "ox": 0,
         "oy": 0
       }
@@ -342,16 +324,14 @@
       "name": "교실 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "CLASSROOM",
       "price": 10,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/교실-바닥.svg",
         "thumb": "/images/thumb/FLOOR/교실-바닥.svg",
-        "shop": "/images/shop/FLOOR/교실-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -361,16 +341,14 @@
       "name": "얼음 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "WINTER",
       "price": 20,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/얼음-바닥.svg",
         "thumb": "/images/thumb/FLOOR/얼음-바닥.svg",
-        "shop": "/images/shop/FLOOR/얼음-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -380,16 +358,14 @@
       "name": "식탁보 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "PICNIC",
       "price": 30,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/식탁보-바닥.svg",
         "thumb": "/images/thumb/FLOOR/식탁보-바닥.svg",
-        "shop": "/images/shop/FLOOR/식탁보-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -399,16 +375,14 @@
       "name": "모래사장 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "SUMMER",
       "price": 40,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/모래사장-바닥.svg",
         "thumb": "/images/thumb/FLOOR/모래사장-바닥.svg",
-        "shop": "/images/shop/FLOOR/모래사장-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -418,16 +392,14 @@
       "name": "쿠키 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "DESSERT",
       "price": 50,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/쿠키-바닥.svg",
         "thumb": "/images/thumb/FLOOR/쿠키-바닥.svg",
-        "shop": "/images/shop/FLOOR/쿠키-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -437,16 +409,14 @@
       "name": "핑크 카펫 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "floor",
+      "slot": "object",
       "theme": "BIRTHDAY",
       "price": 60,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/FLOOR/핑크-카펫-바닥.svg",
         "thumb": "/images/thumb/FLOOR/핑크-카펫-바닥.svg",
-        "shop": "/images/shop/FLOOR/핑크-카펫-바닥.svg",
-        "z": 20,
         "ox": 0,
         "oy": 0
       }
@@ -456,16 +426,14 @@
       "name": "칠판 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "CLASSROOM",
       "price": 10,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/칠판-벽지.svg",
         "thumb": "/images/thumb/WALL/칠판-벽지.svg",
-        "shop": "/images/shop/WALL/칠판-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -475,16 +443,14 @@
       "name": "눈꽃 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "WINTER",
       "price": 20,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/눈꽃-벽지.svg",
         "thumb": "/images/thumb/WALL/눈꽃-벽지.svg",
-        "shop": "/images/shop/WALL/눈꽃-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -494,16 +460,14 @@
       "name": "구름 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "PICNIC",
       "price": 30,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/구름-벽지.svg",
         "thumb": "/images/thumb/WALL/구름-벽지.svg",
-        "shop": "/images/shop/WALL/구름-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -513,16 +477,14 @@
       "name": "조개 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "SUMMER",
       "price": 40,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/조개-벽지.svg",
         "thumb": "/images/thumb/WALL/조개-벽지.svg",
-        "shop": "/images/shop/WALL/조개-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -532,16 +494,14 @@
       "name": "롤리팝 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "DESSERT",
       "price": 50,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/롤리팝-벽지.svg",
         "thumb": "/images/thumb/WALL/롤리팝-벽지.svg",
-        "shop": "/images/shop/WALL/롤리팝-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -551,16 +511,14 @@
       "name": "풍선 벽지",
       "type": "WALL",
       "group": "COMMON",
-      "slot": "wall",
+      "slot": "object",
       "theme": "BIRTHDAY",
       "price": 60,
-      "purchasable": false,
-      "defaultOwned": true,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/WALL/풍선-벽지.svg",
         "thumb": "/images/thumb/WALL/풍선-벽지.svg",
-        "shop": "/images/shop/WALL/풍선-벽지.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -570,15 +528,14 @@
       "name": "도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
-      "theme": "",
-      "price": null,
-      "purchasable": false,
+      "slot": "object",
+      "theme": null,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
         "src": "/images/items/APPAREL/도리.svg",
         "thumb": "/images/thumb/APPAREL/도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -588,15 +545,14 @@
       "name": "학사모 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "CLASSROOM",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 10,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/학사모-도리.svg",
         "thumb": "/images/thumb/APPAREL/학사모-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -606,15 +562,14 @@
       "name": "목도리 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "WINTER",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 20,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/목도리-도리.svg",
         "thumb": "/images/thumb/APPAREL/목도리-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -624,15 +579,14 @@
       "name": "빨간망토 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "PICNIC",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 30,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/빨간망토-도리.svg",
         "thumb": "/images/thumb/APPAREL/빨간망토-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -642,15 +596,14 @@
       "name": "튜브 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "SUMMER",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 40,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/튜브-도리.svg",
         "thumb": "/images/thumb/APPAREL/튜브-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -660,33 +613,31 @@
       "name": "메론빵 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "DESSERT",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 50,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/메론빵-도리.svg",
         "thumb": "/images/thumb/APPAREL/메론빵-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
     },
     "37": {
       "id": "37",
-      "name": "생일파티 도리",
+      "name": "생일파리 도리",
       "type": "APPAREL",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": "BIRTHDAY",
-      "price": null,
-      "purchasable": false,
-      "defaultOwned": true,
+      "price": 60,
+      "purchasable": true,
+      "defaultOwned": false,
       "asset": {
         "src": "/images/items/APPAREL/생일파티-도리.svg",
         "thumb": "/images/thumb/APPAREL/생일파티-도리.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -696,15 +647,14 @@
       "name": "기본 선반",
       "type": "SHELF",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
         "src": "/images/items/SHELF/기본-선반.svg",
         "thumb": "/images/thumb/SHELF/기본-선반.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -714,16 +664,15 @@
       "name": "기본 바닥",
       "type": "FLOOR",
       "group": "COMMON",
-      "slot": "apparel",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
         "src": "/images/items/FLOOR/기본-바닥.svg",
         "thumb": "/images/thumb/FLOOR/기본-바닥.svg",
         "shop": "/images/shop/FLOOR/기본-바닥.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
@@ -733,84 +682,133 @@
       "name": "기본 창문",
       "type": "WINDOW",
       "group": "COMMON",
-      "slot": "window",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
         "src": "/images/items/WINDOW/기본-창문.svg",
         "thumb": "/images/thumb/WINDOW/기본-창문.svg",
-        "shop": "/images/shop/WINDOW/기본-창문.svg",
-        "z": 10,
         "ox": 0,
         "oy": 0
       }
     },
     "41": {
       "id": "41",
-      "name": "맑음",
-      "type": "WEATHER",
+      "name": "감귤 도리",
+      "type": "APPAREL",
       "group": "COMMON",
-      "slot": "",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
-        "src": "/images/items/WEATHER/맑음.svg",
-        "z": 10,
+        "src": "/images/items/APPAREL/감귤-도리.svg",
+        "thumb": "/images/thumb/APPAREL/감귤-도리.svg",
         "ox": 0,
         "oy": 0
       }
     },
     "42": {
       "id": "42",
-      "name": "눈",
-      "type": "WEATHER",
+      "name": "복숭아 도리",
+      "type": "APPAREL",
       "group": "COMMON",
-      "slot": "",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
-        "src": "/images/items/WEATHER/눈.svg",
-        "z": 10,
+        "src": "/images/items/APPAREL/복숭아-도리.svg",
+        "thumb": "/images/thumb/APPAREL/복숭아-도리.svg",
         "ox": 0,
         "oy": 0
       }
     },
     "43": {
       "id": "43",
-      "name": "비",
-      "type": "WEATHER",
+      "name": "부산어묵 도리",
+      "type": "OBJECT",
       "group": "COMMON",
-      "slot": "",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
-        "src": "/images/items/WEATHER/비.svg",
-        "z": 10,
+        "src": "/images/items/APPAREL/부산어묵-도리.svg",
+        "thumb": "/images/thumb/APPAREL/부산어묵-도리.svg",
         "ox": 0,
         "oy": 0
       }
     },
     "44": {
       "id": "44",
-      "name": "흐림",
-      "type": "WEATHER",
+      "name": "반달가슴곰 인형",
+      "type": "OBJECT",
       "group": "COMMON",
-      "slot": "",
+      "slot": "object",
       "theme": null,
-      "price": null,
-      "purchasable": false,
+      "price": 0,
+      "purchasable": true,
       "defaultOwned": true,
       "asset": {
-        "src": "/images/items/WEATHER/흐림.svg",
-        "z": 10,
+        "src": "/images/items/OBJECT/반달가슴곰-인형.svg",
+        "thumb": "/images/thumb/OBJECT/반달가슴곰-인형.svg",
+        "ox": 0,
+        "oy": 0
+      }
+    },
+    "45": {
+      "id": "45",
+      "name": "빨간버스",
+      "type": "OBJECT",
+      "group": "COMMON",
+      "slot": "object",
+      "theme": null,
+      "price": 0,
+      "purchasable": true,
+      "defaultOwned": true,
+      "asset": {
+        "src": "/images/items/OBJECT/빨간버스.svg",
+        "thumb": "/images/thumb/OBJECT/빨간버스.svg",
+        "ox": 0,
+        "oy": 0
+      }
+    },
+    "46": {
+      "id": "46",
+      "name": "해치 인형",
+      "type": "OBJECT",
+      "group": "COMMON",
+      "slot": "object",
+      "theme": null,
+      "price": 0,
+      "purchasable": true,
+      "defaultOwned": true,
+      "asset": {
+        "src": "/images/items/OBJECT/해치-인형.svg",
+        "thumb": "/images/thumb/OBJECT/해치-인형.svg",
+        "ox": 0,
+        "oy": 0
+      }
+    },
+    "47": {
+      "id": "47",
+      "name": "토용 도리",
+      "type": "OBJECT",
+      "group": "COMMON",
+      "slot": "object",
+      "theme": null,
+      "price": 0,
+      "purchasable": true,
+      "defaultOwned": true,
+      "asset": {
+        "src": "/images/items/OBJECT/토용-도리.svg",
+        "thumb": "/images/thumb/OBJECT/토용-도리.svg",
         "ox": 0,
         "oy": 0
       }

--- a/src/data/weather.json
+++ b/src/data/weather.json
@@ -1,0 +1,70 @@
+{
+  "1": {
+    "id": "1",
+    "name": "맑음",
+    "type": "WEATHER",
+    "group": "COMMON",
+    "slot": "",
+    "theme": null,
+    "price": null,
+    "purchasable": false,
+    "defaultOwned": true,
+    "asset": {
+      "src": "/images/items/WEATHER/맑음.svg",
+      "z": 10,
+      "ox": 0,
+      "oy": 0
+    }
+  },
+  "2": {
+    "id": "2",
+    "name": "눈",
+    "type": "WEATHER",
+    "group": "COMMON",
+    "slot": "",
+    "theme": null,
+    "price": null,
+    "purchasable": false,
+    "defaultOwned": true,
+    "asset": {
+      "src": "/images/items/WEATHER/눈.svg",
+      "z": 10,
+      "ox": 0,
+      "oy": 0
+    }
+  },
+  "3": {
+    "id": "3",
+    "name": "비",
+    "type": "WEATHER",
+    "group": "COMMON",
+    "slot": "",
+    "theme": null,
+    "price": null,
+    "purchasable": false,
+    "defaultOwned": true,
+    "asset": {
+      "src": "/images/items/WEATHER/비.svg",
+      "z": 10,
+      "ox": 0,
+      "oy": 0
+    }
+  },
+  "4": {
+    "id": "4",
+    "name": "흐림",
+    "type": "WEATHER",
+    "group": "COMMON",
+    "slot": "",
+    "theme": null,
+    "price": null,
+    "purchasable": false,
+    "defaultOwned": true,
+    "asset": {
+      "src": "/images/items/WEATHER/흐림.svg",
+      "z": 10,
+      "ox": 0,
+      "oy": 0
+    }
+  }
+}

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -30,7 +30,7 @@ export default function useItemAll() {
       const res = await axiosInstance.get('items');
       const raw = Array.isArray(res.data?.content) ? res.data.content : [];
       const apiContent = raw
-        .filter((item) => item?.isPurchasable === true)
+        .filter((item) => item?.isPurchasable === false)
         .map(normalizeItem);
 
       if (!mountedRef.current) return;


### PR DESCRIPTION
# ✨ 작업 사항
### 1. DB 아이템, 프론트 동기화
 DB의 기존 아이템보다 여러가지의 아이템이 추가되면서 로직이 깨지는 문제가 발생했습니다. 때문에 앞으로 아이템 추가를 더 효율적으로 하기 위해 기본 아이템, 상점 아이템, 도감 아이템 등을 구분하여 넣게되었고, 이를 프론트 manifest.json에 맞게 동기화 시켰습니다.


---

# 📸 스크린샷 (선택)
<img width="387" height="876" alt="image" src="https://github.com/user-attachments/assets/c53e6e9f-7fb6-4e6f-ad94-52f5e9183ccc" />


---

# 🔗 참고 자료 (선택)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 새 오브젝트 3종 추가: 빨간버스, 해치 인형, 토용 도리.
  - 기본 날씨 아이템 4종을 카탈로그로 제공(항상 보유).
- Bug Fixes
  - 없음.
- Refactor
  - 아이템 슬롯을 ‘object’로 일원화하고 일부 이름/분류/테마를 정리.
  - 상점에서 구매 가능 항목이 확대되고 모든 가격이 숫자로 명시됨.
  - 불필요한 표시용 메타데이터를 정리해 자산 참조를 간소화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->