### PR TITLE
hotfix: 상점 아이템 안보이는 버그 수정

### DIFF
--- a/src/app/shop/_components/ConfirmModal.js
+++ b/src/app/shop/_components/ConfirmModal.js
@@ -44,7 +44,7 @@ export default function ConfirmModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex justify-center">
+    <div className="fixed inset-0 z-55 flex justify-center">
       <div className="w-full max-w-[390px] bg-black/30 px-4 flex items-center justify-center">
         <div className="flex flex-col gap-4 bg-white rounded-lg shadow-lg w-[90%] max-w-sm px-10 py-6 animate-fade-in">
           <p className="text-center text-gray-800 text-base font-semibold">

--- a/src/app/shop/page.js
+++ b/src/app/shop/page.js
@@ -66,9 +66,9 @@ export default function Shop() {
     <div className="flex justify-center h-screen pt-21 bg-neutral-100">
       <div className="flex flex-col max-w-[390px] w-screen mx-auto">
         {/* 상단 고정: 보유 포인트 (왼쪽 정렬) */}
-        <div className="fixed max-w-[390px] w-screen flex justify-between px-4 z-1">
+        <div className="fixed max-w-[390px] w-screen flex justify-between px-4 z-20">
           <div
-            className="flex justify-center items-center gap-2 rounded-lg w-auto px-2 h-8"
+            className="flex justify-center items-center gap-2 rounded-lg w-auto px-2 h-8 bg-background"
             style={{ boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}
           >
             <FaFire className="trnsform scale-x-[-1] text-main-100 w-5 h-5" />

--- a/src/data/manifest.json
+++ b/src/data/manifest.json
@@ -332,6 +332,7 @@
       "asset": {
         "src": "/images/items/FLOOR/교실-바닥.svg",
         "thumb": "/images/thumb/FLOOR/교실-바닥.svg",
+        "shop": "/images/shop/FLOOR/교실-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -349,6 +350,7 @@
       "asset": {
         "src": "/images/items/FLOOR/얼음-바닥.svg",
         "thumb": "/images/thumb/FLOOR/얼음-바닥.svg",
+        "shop": "/images/shop/FLOOR/얼음-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -366,6 +368,7 @@
       "asset": {
         "src": "/images/items/FLOOR/식탁보-바닥.svg",
         "thumb": "/images/thumb/FLOOR/식탁보-바닥.svg",
+        "shop": "/images/shop/FLOOR/식탁보-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -383,6 +386,7 @@
       "asset": {
         "src": "/images/items/FLOOR/모래사장-바닥.svg",
         "thumb": "/images/thumb/FLOOR/모래사장-바닥.svg",
+        "shop": "/images/shop/FLOOR/모래사장-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -400,6 +404,7 @@
       "asset": {
         "src": "/images/items/FLOOR/쿠키-바닥.svg",
         "thumb": "/images/thumb/FLOOR/쿠키-바닥.svg",
+        "shop": "/images/shop/FLOOR/쿠키-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -417,6 +422,7 @@
       "asset": {
         "src": "/images/items/FLOOR/핑크-카펫-바닥.svg",
         "thumb": "/images/thumb/FLOOR/핑크-카펫-바닥.svg",
+        "shop": "/images/shop/FLOOR/핑크-카펫-바닥.svg",
         "ox": 0,
         "oy": 0
       }
@@ -434,6 +440,7 @@
       "asset": {
         "src": "/images/items/WALL/칠판-벽지.svg",
         "thumb": "/images/thumb/WALL/칠판-벽지.svg",
+        "shop": "/images/shop/WALL/칠판-벽지.svg",
         "ox": 0,
         "oy": 0
       }
@@ -451,6 +458,7 @@
       "asset": {
         "src": "/images/items/WALL/눈꽃-벽지.svg",
         "thumb": "/images/thumb/WALL/눈꽃-벽지.svg",
+        "shop": "/images/shop/WALL/눈꽃-벽지.svg",
         "ox": 0,
         "oy": 0
       }
@@ -468,6 +476,7 @@
       "asset": {
         "src": "/images/items/WALL/구름-벽지.svg",
         "thumb": "/images/thumb/WALL/구름-벽지.svg",
+        "shop": "/images/shop/WALL/구름-벽지.svg",
         "ox": 0,
         "oy": 0
       }
@@ -485,6 +494,7 @@
       "asset": {
         "src": "/images/items/WALL/조개-벽지.svg",
         "thumb": "/images/thumb/WALL/조개-벽지.svg",
+        "shop": "/images/shop/WALL/조개-벽지.svg",
         "ox": 0,
         "oy": 0
       }
@@ -502,6 +512,7 @@
       "asset": {
         "src": "/images/items/WALL/롤리팝-벽지.svg",
         "thumb": "/images/thumb/WALL/롤리팝-벽지.svg",
+        "shop": "/images/shop/WALL/롤리팝-벽지.svg",
         "ox": 0,
         "oy": 0
       }
@@ -519,6 +530,7 @@
       "asset": {
         "src": "/images/items/WALL/풍선-벽지.svg",
         "thumb": "/images/thumb/WALL/풍선-벽지.svg",
+        "shop": "/images/shop/WALL/풍선-벽지.svg",
         "ox": 0,
         "oy": 0
       }

--- a/src/hooks/shop/useItemAll.js
+++ b/src/hooks/shop/useItemAll.js
@@ -30,7 +30,7 @@ export default function useItemAll() {
       const res = await axiosInstance.get('items');
       const raw = Array.isArray(res.data?.content) ? res.data.content : [];
       const apiContent = raw
-        .filter((item) => item?.isPurchasable === false)
+        .filter((item) => item?.isPurchasable)
         .map(normalizeItem);
 
       if (!mountedRef.current) return;

--- a/src/hooks/shop/usePurchase.js
+++ b/src/hooks/shop/usePurchase.js
@@ -21,6 +21,7 @@ export default function usePurchase(handler) {
 
   const mountedRef = useRef(true);
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };


### PR DESCRIPTION
# ✨ 작업 사항
### 1. 상점에서 상점 아이템이 아닌 도감 아이템이 뜨는 버그 수정

### 2. 벽지와 바닥 프리뷰 착용이 되지 않는 버그 수정


---

# 📸 스크린샷 (선택)
<img width="387" height="876" alt="image" src="https://github.com/user-attachments/assets/a8c7459c-6048-4e46-8b42-54ea6f9473c2" />
<img width="387" height="876" alt="image" src="https://github.com/user-attachments/assets/76189415-f3c2-41f8-b4d4-c2b8de4c5ad5" />

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [ ] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [ ] 이 PR이 관련된 이슈와 연결되었나요?
- [ ] 팀원들과 논의가 필요한 부분이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 상점에서 구매 가능한 아이템만 목록에 표시됩니다.
  - 다수의 바닥/벽지 아이템에 상점용 이미지가 추가되어 미리보기 품질이 향상되었습니다.
- Style
  - 상단 고정 헤더에 배경이 추가되고 표시 우선순위가 높아져 시각적 안정성이 개선되었습니다.
  - 구매 확인 모달의 표시 우선순위가 올라 모달이 다른 요소 위에 안정적으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->