### PR TITLE
feat: 말풍선 UI 구현

### DIFF
--- a/public/images/bubble.svg
+++ b/public/images/bubble.svg
@@ -1,0 +1,17 @@
+<svg width="192" height="98" viewBox="0 0 192 98" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2660_15200)">
+<path d="M178 4.28516C183.523 4.28516 188 8.76231 188 14.2852V72.2852C188 77.808 183.523 82.2852 178 82.2852H154.61L152.226 91.7686C151.718 93.7848 148.853 93.7848 148.346 91.7686L145.961 82.2852H14C8.47715 82.2852 4 77.808 4 72.2852V14.2852C4 8.76231 8.47715 4.28516 14 4.28516H178Z" fill="#FEFEFE"/>
+</g>
+<defs>
+<filter id="filter0_d_2660_15200" x="0" y="0.285156" width="192" height="96.9951" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2660_15200"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2660_15200" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/app/home/edit-intro/page.js
+++ b/src/app/home/edit-intro/page.js
@@ -3,6 +3,7 @@
 import EditHeaderNavBar from '@/app/mypage/_components/EditHeaderNavBar';
 import usePutSpeech from '@/hooks/user/usePutSpeech';
 import LoadingContent from '@/app/_components/LoadingContent';
+import useMyRoom from '@/hooks/user/useMyRoom';
 import { useToast } from '@/app/_providers/ToastProvider';
 import { useEffect, useState } from 'react';
 
@@ -10,6 +11,13 @@ export default function page() {
   const [context, setContext] = useState('');
   const { mutate, data, loading, error } = usePutSpeech();
   const { show } = useToast();
+  const { data: myRoom } = useMyRoom();
+
+  useEffect(() => {
+    if (myRoom?.speechBubble !== null) {
+      setContext(myRoom.speechBubble ?? '');
+    }
+  }, [myRoom?.speechBubble]);
 
   useEffect(() => {
     if (data?.statusCode === 400) show(data?.error);

--- a/src/app/home/edit-intro/page.js
+++ b/src/app/home/edit-intro/page.js
@@ -1,13 +1,35 @@
 'use client';
 
 import EditHeaderNavBar from '@/app/mypage/_components/EditHeaderNavBar';
-import { useState } from 'react';
+import usePutSpeech from '@/hooks/user/usePutSpeech';
+import LoadingContent from '@/app/_components/LoadingContent';
+import { useToast } from '@/app/_providers/ToastProvider';
+import { useEffect, useState } from 'react';
 
 export default function page() {
   const [context, setContext] = useState('');
+  const { mutate, data, loading, error } = usePutSpeech();
+  const { show } = useToast();
+
+  useEffect(() => {
+    if (data?.statusCode === 400) show(data?.error);
+    else if (data?.statusCode === 200)
+      show({
+        message: '한줄소개가 정상적으로 등록되었어요!',
+        variant: 'success',
+      });
+  }, [data]);
+
+  if (loading) return <LoadingContent loading={loading} />;
+
   return (
     <div className="w-screen h-screen px-4 pt-28">
-      <EditHeaderNavBar title="한줄소개" />
+      <EditHeaderNavBar
+        title="한줄소개"
+        onClick={async () => {
+          await mutate({ speechBubble: context });
+        }}
+      />
       <div className="space-y-4">
         <p className="font-semibold text-base">한줄소개를 입력해 주세요.</p>
         <div className="bg-neutral-100 rounded-lg p-4 font-medium">

--- a/src/app/home/edit-intro/page.js
+++ b/src/app/home/edit-intro/page.js
@@ -4,6 +4,7 @@ import EditHeaderNavBar from '@/app/mypage/_components/EditHeaderNavBar';
 import usePutSpeech from '@/hooks/user/usePutSpeech';
 import LoadingContent from '@/app/_components/LoadingContent';
 import useMyRoom from '@/hooks/user/useMyRoom';
+import { useRouter } from 'next/navigation';
 import { useToast } from '@/app/_providers/ToastProvider';
 import { useEffect, useState } from 'react';
 
@@ -13,19 +14,23 @@ export default function page() {
   const { show } = useToast();
   const { data: myRoom } = useMyRoom();
 
+  const router = useRouter();
+
   useEffect(() => {
-    if (myRoom?.speechBubble !== null) {
+    if (myRoom?.speechBubble != null) {
       setContext(myRoom.speechBubble ?? '');
     }
   }, [myRoom?.speechBubble]);
 
   useEffect(() => {
     if (data?.statusCode === 400) show(data?.error);
-    else if (data?.statusCode === 200)
+    else if (data?.statusCode === 200) {
       show({
         message: '한줄소개가 정상적으로 등록되었어요!',
         variant: 'success',
       });
+      router.back();
+    }
   }, [data]);
 
   if (loading) return <LoadingContent loading={loading} />;

--- a/src/app/home/edit-intro/page.js
+++ b/src/app/home/edit-intro/page.js
@@ -1,0 +1,28 @@
+'use client';
+
+import EditHeaderNavBar from '@/app/mypage/_components/EditHeaderNavBar';
+import { useState } from 'react';
+
+export default function page() {
+  const [context, setContext] = useState('');
+  return (
+    <div className="w-screen h-screen px-4 pt-28">
+      <EditHeaderNavBar title="한줄소개" />
+      <div className="space-y-4">
+        <p className="font-semibold text-base">한줄소개를 입력해 주세요.</p>
+        <div className="bg-neutral-100 rounded-lg p-4 font-medium">
+          <textarea
+            className="focus:outline-none h-10 w-full text-sm"
+            placeholder="내용 입력하기"
+            maxLength={30}
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+          />
+          <p className="text-right text-sm text-neutral-400">
+            ({context.length}/30자)
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/neighbor/[userId]/page.js
+++ b/src/app/neighbor/[userId]/page.js
@@ -221,8 +221,10 @@ export default function NeighborHome() {
 
             {/* 말풍선 전체를 덮는 레이어 */}
             <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
-              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
-                제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.
+              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-xs">
+                {room?.speechBubble
+                  ? room?.speechBubble
+                  : '한줋소개가 추가되지 않았아요.'}
               </p>
             </div>
           </div>

--- a/src/app/neighbor/[userId]/page.js
+++ b/src/app/neighbor/[userId]/page.js
@@ -224,7 +224,7 @@ export default function NeighborHome() {
               <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-xs">
                 {room?.speechBubble
                   ? room?.speechBubble
-                  : '한줋소개가 추가되지 않았아요.'}
+                  : '한줄소개가 추가되지 않았아요.'}
               </p>
             </div>
           </div>

--- a/src/app/neighbor/[userId]/page.js
+++ b/src/app/neighbor/[userId]/page.js
@@ -211,14 +211,30 @@ export default function NeighborHome() {
         </div>
 
         {/* APPAREL */}
-        <img
-          src={
-            manifest.items[selectAPPAREL?.itemId]?.asset.src ||
-            manifest.items[DEFAULT_APPAREL]?.asset.src
-          }
-          className={`absolute`}
-          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 170 }}
-        />
+        <div
+          className="absolute"
+          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 200 }}
+        >
+          <div className="relative">
+            {/* 말풍선 이미지 */}
+            <img src="/images/bubble.svg" />
+
+            {/* 말풍선 전체를 덮는 레이어 */}
+            <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
+              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
+                제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.
+              </p>
+            </div>
+          </div>
+
+          <img
+            src={
+              manifest.items[selectAPPAREL?.itemId]?.asset.src ||
+              manifest.items[DEFAULT_APPAREL]?.asset.src
+            }
+            className="-mt-8"
+          />
+        </div>
       </div>
 
       {/* 하단 정보 */}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -146,14 +146,31 @@ export default function Home() {
         </div>
 
         {/* APPAREL */}
-        <img
-          src={
-            manifest.items[selectAPPAREL?.itemId]?.asset.src ||
-            manifest.items[DEFAULT_APPAREL]?.asset.src
-          }
-          className={`absolute`}
-          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 140 }}
-        />
+        <div
+          className="absolute"
+          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 200 }}
+        >
+          <div className="relative">
+            {/* 말풍선 이미지 */}
+            <img src="/images/bubble.svg" />
+
+            {/* 말풍선 전체를 덮는 레이어 */}
+            <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
+              <p className="text-center break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
+                제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.{' '}
+                <i className="mgc_pencil_fill text-neutral-400" />
+              </p>
+            </div>
+          </div>
+
+          <img
+            src={
+              manifest.items[selectAPPAREL?.itemId]?.asset.src ||
+              manifest.items[DEFAULT_APPAREL]?.asset.src
+            }
+            className="-mt-8"
+          />
+        </div>
       </div>
 
       <RoomStatsCard

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -156,7 +156,9 @@ export default function Home() {
 
             {/* 말풍선 전체를 덮는 레이어 */}
             <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
-              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-xs">
+              <p
+                className={`text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-xs ${data?.speechBubble ? 'text-black' : 'text-neutral-400'}`}
+              >
                 {data?.speechBubble
                   ? data?.speechBubble
                   : '한줄소개를 추가해 보세요!'}{' '}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -158,7 +158,10 @@ export default function Home() {
             <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
               <p className="text-center break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
                 제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.{' '}
-                <i className="mgc_pencil_fill text-neutral-400" />
+                <i
+                  className="mgc_pencil_fill text-neutral-400"
+                  onClick={() => router.push('/home/edit-intro')}
+                />
               </p>
             </div>
           </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -148,7 +148,7 @@ export default function Home() {
         {/* APPAREL */}
         <div
           className="absolute"
-          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 200 }}
+          style={{ zIndex: zIndex.APPAREL, top: DEFAULT_H - 220 }}
         >
           <div className="relative">
             {/* 말풍선 이미지 */}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -156,8 +156,10 @@ export default function Home() {
 
             {/* 말풍선 전체를 덮는 레이어 */}
             <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
-              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
-                제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.{' '}
+              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-xs">
+                {data?.speechBubble
+                  ? data?.speechBubble
+                  : '한줄소개를 추가해 보세요!'}{' '}
                 <i
                   className="mgc_pencil_fill text-neutral-400"
                   onClick={() => router.push('/home/edit-intro')}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -156,7 +156,7 @@ export default function Home() {
 
             {/* 말풍선 전체를 덮는 레이어 */}
             <div className="absolute inset-0 bottom-2 flex items-center justify-center px-4">
-              <p className="text-center break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
+              <p className="text-justify break-words [overflow-wrap:anywhere] whitespace-pre-wrap max-w-full font-normal text-sm">
                 제 방에 오신 것을 환영합니다. 제 방에 오신 것을 환영합니다.{' '}
                 <i
                   className="mgc_pencil_fill text-neutral-400"

--- a/src/hooks/user/useMyRoom.js
+++ b/src/hooks/user/useMyRoom.js
@@ -10,6 +10,7 @@ function normalizeMyRoom(item) {
     viewCount: item.viewCount,
     likeCount: item.likeCount,
     credit: item.credit,
+    speechBubble: item.speechBubble,
   };
 }
 

--- a/src/hooks/user/usePutSpeech.js
+++ b/src/hooks/user/usePutSpeech.js
@@ -1,0 +1,47 @@
+'use client';
+
+import axiosInstance from '@/lib/axiosInstance';
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export default function usePutSpeech() {
+  const [data, setData] = useState();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const mutate = useCallback(
+    async ({ speechBubble }) => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await axiosInstance.put('users/speechbubble', {
+          speechBubble,
+        });
+
+        const apiContent = res.data;
+        if (!mountedRef.current) return;
+        setData(apiContent);
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setError(err);
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    },
+    [loading]
+  );
+
+  const reset = () => {
+    setError(null);
+  };
+
+  return { mutate, data, loading, error, reset };
+}


### PR DESCRIPTION
# 🔗 관련 이슈
Closes Dori-room#52

---

# ✨ 작업 사항
### 1. 말풍선 UI 구현
홈, 이웃홈 화면에서 말풍선 UI를 구현하였습니다.

### 2. 말풍선 수정 페이지
말풍선 수정 페이지를 구현하였습니다. 홈 화면 말풍선에서 연필모양 버튼을 클릭하는 것으로 이동할 수 있고, textarea를 통해 입력을 받았습니다. 최대 30자까지 입력을 할 수 있게 설정해놓았고, 상단 헤더의 확인 버튼을 클릭하는 것으로 말풍선을 수정할 수 있습니다. status Code에 따라 toast 메세지를 뜨게 설정해두었습니다.


---

# 📸 스크린샷 (선택)

<img width="357" height="798" alt="image" src="https://github.com/user-attachments/assets/664496ce-3d7a-4b07-9e54-f7a8c1e78f82" />
<img width="357" height="798" alt="image" src="https://github.com/user-attachments/assets/973873aa-996a-41a2-9672-a997f7e73da3" />
<img width="357" height="798" alt="image" src="https://github.com/user-attachments/assets/c998ddfa-4e64-4298-b1c8-64fa80fea6e1" />

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면과 앱 전반에 의상 이미지 위 말풍선 오버레이가 추가되어 한줄 소개를 표시합니다.
  * 홈의 연필 아이콘으로 한줄 소개 편집 화면으로 이동해 소개를 수정할 수 있습니다.
  * 편집 페이지: 최대 30자 입력, 실시간 글자수 표시, 저장 시 로딩 표시 및 성공/오류 토스트 알림 제공.
  * 이웃 프로필에도 말풍선 UI가 추가되어 한줄 소개 또는 기본 문구가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->