### PR TITLE
hotfix: 회원가입 및 프로필 이미지 업로드 로직 분리

### DIFF
--- a/src/app/festival/search/result/page.js
+++ b/src/app/festival/search/result/page.js
@@ -398,7 +398,7 @@ export default function FestivalSearchResultPage() {
         />
       )}
       <div
-        className={`fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[390px] z-[100]
+        className={`fixed bottom-0 left-1/2 -translate-x-1/2 w-full z-[100]
         bg-background rounded-t-xl px-4 py-8 transition-transform duration-300 ease-in-out
         ${sheet ? 'translate-y-0' : 'translate-y-[100vh]'}`}
       >

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -54,16 +54,11 @@ export default function Home() {
   }, [granted, location?.lat, location?.lng, refetch]);
 
   if (loading)
-    return (
-      <LoadingContent
-        loading={loading}
-        className="max-w-[390px] w-screen h-screen"
-      />
-    );
+    return <LoadingContent loading={loading} className="w-screen h-screen" />;
 
   if (error || !data) {
     return (
-      <div className="max-w-[390px] w-screen h-screen flex items-center justify-center text-red-500">
+      <div className="w-screen h-screen flex items-center justify-center text-red-500">
         데이터를 불러오는 중 오류가 발생했습니다.
       </div>
     );

--- a/src/app/signup/info/page.js
+++ b/src/app/signup/info/page.js
@@ -201,7 +201,6 @@ export default function SignupInfoPage() {
     setGlobalErr(null);
 
     if (!formValid) {
-      // 어떤 것이 부족한지 안내
       if (!usernameFormatOk)
         return setGlobalErr('아이디 형식을 확인해 주세요.');
       if (!uidCheckedAndValid)
@@ -221,8 +220,8 @@ export default function SignupInfoPage() {
         username: usernameRaw,
         password: profile.password,
         nickname: nicknameRaw,
-        avatarFile: profile.avatarFile,
       });
+
       router.replace('/signup/profileImage');
     } catch (e2) {
       setGlobalErr(extractErrorMessage(e2) || '회원가입에 실패했습니다.');

--- a/src/app/signup/profileImage/page.js
+++ b/src/app/signup/profileImage/page.js
@@ -6,7 +6,7 @@ import { useSignupStore } from '@/stores/useSignupStore';
 import HeaderNavigationBar from '@/app/_components/HeaderNavigationBar';
 import ImageUploader from '@/app/_components/ImageUploader';
 import PrimaryButton from '@/app/_components/PrimaryButton';
-import { submitSignupProfile } from '@/hooks/auth/useSignup';
+import { uploadProfileImage } from '@/hooks/auth/useSignup';
 import LoadingModal from '@/app/_components/LoadingModal';
 
 export default function SignupAvatarPage() {
@@ -34,6 +34,7 @@ export default function SignupAvatarPage() {
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
+
   useEffect(() => {
     const style = document.createElement('style');
     style.textContent =
@@ -42,17 +43,11 @@ export default function SignupAvatarPage() {
     return () => document.head.removeChild(style);
   }, []);
 
-  async function finishSignup(withImage) {
-    if (loading) return;
+  async function handleUpload() {
+    if (loading || !profile.profileImage) return;
     setLoading(true);
     try {
-      await submitSignupProfile({
-        email,
-        username: profile.username,
-        password: profile.password,
-        nickname: profile.nickname,
-        profileImage: withImage ? profile.profileImage : null,
-      });
+      await uploadProfileImage(profile.profileImage);
       reset();
       router.replace('/login');
     } finally {
@@ -95,7 +90,7 @@ export default function SignupAvatarPage() {
           <button
             type="button"
             disabled={loading}
-            onClick={() => finishSignup(false)}
+            onClick={() => router.replace('/login')}
             className="w-18 text-sm text-neutral-400 border-b-1 border-neutral-400 mb-4"
           >
             다음에 하기
@@ -103,8 +98,8 @@ export default function SignupAvatarPage() {
 
           <PrimaryButton
             type="button"
-            disabled={loading}
-            onClick={() => finishSignup(true)}
+            disabled={loading || !profile.profileImage}
+            onClick={handleUpload}
           >
             가입 완료
           </PrimaryButton>

--- a/src/hooks/auth/useSignup.js
+++ b/src/hooks/auth/useSignup.js
@@ -69,28 +69,25 @@ export async function submitSignupProfile({
   username,
   password,
   nickname,
-  profileImage,
 }) {
   try {
+    const payload = { email, username, password, nickname };
+    const res = await axiosInstance.post('/auth/signup', payload);
+    return res.data;
+  } catch (e) {
+    throw toReadableError(e);
+  }
+}
+
+// 프로필 이미지 업로드
+export async function uploadProfileImage(file) {
+  try {
     const formData = new FormData();
+    formData.append('file', file);
 
-    const requestPayload = JSON.stringify({
-      username,
-      password,
-      email,
-      nickname,
+    const res = await axiosInstance.post('/users/me/profile-image', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
     });
-    formData.append(
-      'request',
-      new Blob([requestPayload], { type: 'application/json' })
-    );
-
-    if (profileImage instanceof File) {
-      formData.append('image', profileImage);
-    }
-
-    const res = await axiosInstance.post('/auth/signup', formData);
-
     return res.data;
   } catch (e) {
     throw toReadableError(e);


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
백엔드 로직 변경 요청으로 인해 회원가입 과정에서 프로필 이미지 업로드 로직을 분리하였습니다.

기존에는 /api/auth/signup 요청 시 사용자 정보와 프로필 이미지를 함께 FormData로 전송하는 방식이었으나,
백엔드가 회원가입 엔드포인트에서 JSON 데이터만 처리하도록 변경되면서 이미지 업로드가 별도 API(/api/users/me/profile-image)로 이관되었습니다.
이에 따라 프론트엔드에서는 회원가입 정보 제출과 프로필 이미지 업로드를 각각의 독립된 요청으로 처리하도록 전체 로직을 수정했습니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [ ] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [ ] 이 PR이 관련된 이슈와 연결되었나요?
- [ ] 팀원들과 논의가 필요한 부분이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 회원가입에서 프로필 이미지 업로드가 별도 단계로 분리되었습니다.
  - 이미지 업로드 후 로그인 화면으로 이동합니다.
  - 이미지가 없거나 업로드 중일 때는 “가입 완료” 버튼이 비활성화됩니다.
  - “다음에 하기”를 통해 이미지 업로드를 건너뛸 수 있습니다.

- 개선사항
  - 축제 검색 결과 하단 시트가 전체 너비로 표시되어 가시성이 향상되었습니다.
  - 로딩/에러 화면이 전체 화면으로 단순화되어 일관된 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->